### PR TITLE
fix: commentモードとIn Reviewステータスでの不具合緩和

### DIFF
--- a/guildbotics/modes/comment_mode.py
+++ b/guildbotics/modes/comment_mode.py
@@ -26,7 +26,7 @@ class CommentMode(ModeBase):
 
         git_tool = await self.checkout()
         message = await reply_as(self.context, messages, git_tool.repo_path)
-        return AgentResponse(status=AgentResponse.DONE, message=message)
+        return AgentResponse(status=AgentResponse.ASKING, message=message)
 
     @classmethod
     def get_dependent_services(cls) -> list[Service]:

--- a/tests/guildbotics/modes/test_comment_mode.py
+++ b/tests/guildbotics/modes/test_comment_mode.py
@@ -78,6 +78,6 @@ async def test_run_returns_asking_and_uses_reply_as(monkeypatch, fake_context):
 
     res = await mode.run(messages)
 
-    assert res.status == AgentResponse.DONE
+    assert res.status == AgentResponse.ASKING
     assert isinstance(res.message, str) and res.message.strip() != ""
     assert res.message == "mocked reply"


### PR DESCRIPTION
以下の対応を実施:

- PRが未作成のチケットがIn Review ステータスにある場合、PRを無視して処理を行うようにする
- commentモードで実行する場合、コメント追加時に In Review にチケットを移動しないようにする
