### PR TITLE
ドキュメントとテストコードのちょっとした修正

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -425,9 +425,9 @@ default: gemini-cli.yml
 
 > より詳細な作成・運用方法は [docs/custom_command_guide.ja.md](docs/custom_command_guide.ja.md) を参照してください。
 
-- 記述例: `// <name> [args...]`
-  - 例: `// code-review target=src/app.py level=deep`
-  - コマンド名の末尾にコロンを付けても可: `// code-review: target=...`
+- 記述例: `//<name> [args...]`
+  - 例: `//code-review target=src/app.py level=deep`
+  - コマンド名の末尾にコロンを付けても可: `//code-review: target=...`
 
 プロンプトファイルの探索順（最初に見つかったものを使用）:
 - メンバー単位: `.guildbotics/config/team/members/<person_id>/prompts/<name>.<lang>.md` → `<name>.en.md` → `<name>.md`
@@ -449,14 +449,14 @@ template_engine: jinja2  # または "default"
 ```
 
 引数の渡し方とテンプレート:
-- キー指定: `// review target="src/app.py" level=deep`
+- キー指定: `//review target="src/app.py" level=deep`
   - 引用付き値をサポート（空白を保持）
 - 位置引数も利用可能:
   - `template_engine: jinja2` の場合: `{{ arg1 }}`, `{{ arg2 }}` ...
   - `template_engine: default` の場合: `{{1}}`, `{1}`, `${1}`, `$1` など（名前付きキーも可: `{{target}}`, `{target}`, `${target}`, `$target`）
 
 利用のコツ:
-- コメントを書いた場合は一番新しい（一番最後の）コメントに `// <name> ...` を記述してください。
+- コメントを書いた場合は一番新しい（一番最後の）コメントに `//<name> ...` を記述してください。
 - 再利用したいプロンプトは `.guildbotics/config/prompts/` に、メンバー別の上書きは `.guildbotics/config/team/members/<person_id>/prompts/` に配置します。
 
 

--- a/README.md
+++ b/README.md
@@ -420,9 +420,9 @@ By default, all AI agents share the same CLI agent, but if `team/members/<person
 > For detailed creation and operation, see docs/custom_command_guide.en.md
 You can embed and execute custom command prompts in ticket descriptions or comments by writing a line that starts with `//`.
 
-- Write in the ticket: `// <name> [args...]`
-  - Example: `// code-review target=src/app.py level=deep`
-  - A trailing colon after the name is allowed: `// code-review: target=...`
+- Write in the ticket: `//<name> [args...]`
+  - Example: `//code-review target=src/app.py level=deep`
+  - A trailing colon after the name is allowed: `//code-review: target=...`
 - The system replaces that line with the body of a prompt file before the agent runs.
 
 Prompt file resolution order (first match wins):
@@ -445,14 +445,14 @@ Steps:
 ```
 
 Argument passing and templating:
-- Key-value args: `// review target="src/app.py" level=deep`
+- Key-value args: `//review target="src/app.py" level=deep`
 - Quoted values are supported (spaces preserved).
 - Positional args are also supported:
   - With `template_engine: jinja2`, use `{{ arg1 }}`, `{{ arg2 }}`, ...
   - With `template_engine: default`, use placeholders like `{{1}}`, `{1}`, `${1}`, or `$1` (named keys also work: `{{target}}`, `{target}`, `${target}`, `$target`).
 
 -Usage tips:
-- If you add a comment, write the `// <name> ...` line in the newest (last) comment.
+- If you add a comment, write the `//<name> ...` line in the newest (last) comment.
 - Create reusable prompts under `.guildbotics/config/prompts/` and override per agent under `.guildbotics/config/team/members/<person_id>/prompts/`.
 
 

--- a/docs/custom_command_guide.en.md
+++ b/docs/custom_command_guide.en.md
@@ -131,6 +131,7 @@ Team members:
 {% endfor %}
 ```
 
+- With `brain: none`, the LLM is not called; only subcommand outputs are used as the final result.
 
 ## 3. Using the CLI agent
 

--- a/docs/custom_command_guide.ja.md
+++ b/docs/custom_command_guide.ja.md
@@ -135,6 +135,7 @@ ID: {{ context.person.person_id }}
 {% endfor %}
 ```
 
+- `brain: none` を指定すると、LLM呼び出しが行われず、サブコマンドの出力のみが最終結果として返されます。
 
 ## 3. CLIエージェントの利用
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import contextlib
 import logging
 
 import pytest
@@ -101,3 +102,22 @@ def stub_brain(fake_context):
         fake_context._brains[name] = FakeBrain(result, response_class)
 
     return _stub
+
+
+@contextlib.contextmanager
+def coverage_suspended():
+    cov = None
+    try:
+        import coverage
+
+        cov = coverage.Coverage.current()
+    except Exception:
+        cov = None
+
+    if cov is not None:
+        cov.stop()
+    try:
+        yield
+    finally:
+        if cov is not None:
+            cov.start()

--- a/tests/guildbotics/cli/test_custom_command_guide_examples.py
+++ b/tests/guildbotics/cli/test_custom_command_guide_examples.py
@@ -3,9 +3,13 @@ from pathlib import Path
 
 import pytest
 
-from guildbotics.drivers.custom_command_runner import CustomCommandExecutor, run_custom_command
+from guildbotics.drivers.custom_command_runner import (
+    CustomCommandExecutor,
+    run_custom_command,
+)
 from guildbotics.entities.team import Person, Project, Team
 from guildbotics.runtime.context import Context
+from tests.conftest import coverage_suspended
 from tests.guildbotics.runtime.test_context import (
     DummyBrainFactory,
     DummyIntegrationFactory,
@@ -26,7 +30,9 @@ def _make_context(message: str = "", members: list[Person] | None = None) -> Con
     integration_factory = DummyIntegrationFactory()
     brain_factory = DummyBrainFactory()
     # Use default, then clone to first active person for deterministic person binding
-    base = Context.get_default(loader_factory, integration_factory, brain_factory, message)
+    base = Context.get_default(
+        loader_factory, integration_factory, brain_factory, message
+    )
     for m in members:
         if m.is_active:
             return base.clone_for(m)
@@ -145,7 +151,8 @@ async def test_context_variables_in_jinja2(tmp_path, monkeypatch):
     ]
     ctx = _make_context("", members)
     ex = CustomCommandExecutor(ctx, "context-info", [])
-    out = await ex.run()
+    with coverage_suspended():
+        out = await ex.run()
     assert "言語コード: en" in out
     assert "言語名: English" in out
     assert "ID: alice" in out and "名前: Alice" in out
@@ -180,7 +187,9 @@ async def test_cli_agent_brain_cli_passes_cwd_and_params(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_builtin_command_in_pipeline_identify_item_args_passed(tmp_path, monkeypatch):
+async def test_builtin_command_in_pipeline_identify_item_args_passed(
+    tmp_path, monkeypatch
+):
     monkeypatch.setenv("GUILDBOTICS_CONFIG_DIR", str(tmp_path))
     _write(
         tmp_path / "prompts/get-time-of-day.md",

--- a/tests/guildbotics/intelligences/test_functions.py
+++ b/tests/guildbotics/intelligences/test_functions.py
@@ -313,7 +313,7 @@ def test_preprocess_handles_quoted_arguments(monkeypatch, fake_context, tmp_path
 
     monkeypatch.setattr(f, "get_body_from_prompt", fake_get_body)
 
-    text = "// test-command key=\"value with spaces\" 'single quoted arg' plain"
+    text = "//test-command key=\"value with spaces\" 'single quoted arg' plain"
     out = f.preprocess(ctx, text)
 
     assert out == "processed"


### PR DESCRIPTION
ドキュメントの改善とテストインフラの強化を導入。

**ドキュメントの更新:**

* カスタムコマンドガイドに `brain: none` オプションの説明を追加し、この設定時にはLLMが呼び出されず、サブコマンドの出力のみが最終結果として使用されることを明確にしました。(`docs/custom_command_guide.en.md`, `docs/custom_command_guide.ja.md`)

**テストインフラの改善:**

一部のテストがカバレッジ取得の影響で長時間化していたため、特定のテストでカバレッジレポート取得を停止できるようにしました。

* `tests/conftest.py` に新しい `coverage_suspended` コンテキストマネージャーを導入し、テスト中にコードカバレッジ測定を選択的に一時停止できるようにしました。
* `tests/guildbotics/cli/test_custom_command_guide_examples.py` の中で処理に時間がかかるテストで新しい `coverage_suspended` コンテキストマネージャーを使用するように変更。