### PR TITLE
guildbotics CLIのadd, init, verifyをconfigのサブコマンドに変更

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -158,10 +158,10 @@ uv tool install guildbotics
 以下のコマンドで初期セットアップを行ってください。
 
 ```bash
-guildbotics init
+guildbotics config init
 ```
 
-`guildbotics init` では、以下の内容をターミナル上で対話的に選択・入力した後、設定ファイルを生成します。
+`guildbotics config init` では、以下の内容をターミナル上で対話的に選択・入力した後、設定ファイルを生成します。
 
 - 言語の選択
   - 英語または日本語を選択
@@ -195,10 +195,10 @@ guildbotics init
 以下のコマンドでメンバーを追加できます。
 
 ```bash
-guildbotics add
+guildbotics config add
 ```
 
-`guildbotics add` では、プロジェクトメンバー（AIエージェントもしくは人間）の情報を対話的に入力することで、設定ファイルを生成します。
+`guildbotics config add` では、プロジェクトメンバー（AIエージェントもしくは人間）の情報を対話的に入力することで、設定ファイルを生成します。
 
 - メンバータイプの選択
   - 人間、マシンアカウント、GitHub App、代理エージェント（自分自身のアカウント利用）のいずれかを選択
@@ -239,7 +239,7 @@ guildbotics add
 - GitHub Projects のステータス紐付け設定
 
 ```bash
-guildbotics verify
+guildbotics config verify
 ```
 
 ### 5.3.1. カスタムフィールドの追加

--- a/README.md
+++ b/README.md
@@ -157,10 +157,10 @@ uv tool install guildbotics
 Run the following for initial setup:
 
 ```bash
-guildbotics init
+guildbotics config init
 ```
 
-`guildbotics init` is interactive in your terminal and then generates configuration files. You will:
+`guildbotics config init` is interactive in your terminal and then generates configuration files. You will:
 
 - Select language
   - English or Japanese
@@ -194,10 +194,10 @@ The following files are created/updated:
 Add members with:
 
 ```bash
-guildbotics add
+guildbotics config add
 ```
 
-`guildbotics add` interactively prompts for member (AI agent or human) information and generates configuration files.
+`guildbotics config add` interactively prompts for member (AI agent or human) information and generates configuration files.
 
 - Select member type
   - Choose one of: human, machine account, GitHub App, proxy agent (use your own account)
@@ -238,7 +238,7 @@ Run the following to verify configuration and perform the steps below:
 - Map GitHub Projects status columns
 
 ```bash
-guildbotics verify
+guildbotics config verify
 ```
 
 ### 5.3.1. Add Custom Fields

--- a/docs/custom_command_guide.en.md
+++ b/docs/custom_command_guide.en.md
@@ -62,7 +62,7 @@ This leads the LLM to respond with "こんにちは".
 
 ### 1.3. Select a member
 
-If you have multiple members registered via `guildbotics add`, you must specify a member when running a command using the `<command>@<person_id>` form.
+If you have multiple members registered via `guildbotics config add`, you must specify a member when running a command using the `<command>@<person_id>` form.
 
 Example: `guildbotics run translate@yuki English Japanese`
 

--- a/docs/custom_command_guide.ja.md
+++ b/docs/custom_command_guide.ja.md
@@ -62,7 +62,7 @@ Hello
 
 ### 1.3. メンバーの指定
 
-`guildbotics add` コマンドにより、複数のメンバーを登録している場合、コマンド実行時に `<コマンド>@<person_id>` の形式でメンバーを指定する必要があります。 
+`guildbotics config add` コマンドにより、複数のメンバーを登録している場合、コマンド実行時に `<コマンド>@<person_id>` の形式でメンバーを指定する必要があります。 
 
 例: `guildbotics run translate@yuki 英語 日本語`
 

--- a/guildbotics/cli/__init__.py
+++ b/guildbotics/cli/__init__.py
@@ -245,14 +245,20 @@ def _parse_command_spec(command_spec: str) -> tuple[str, str | None]:
     return name, person
 
 
-@main.command()
+@main.group()
+def config() -> None:
+    """Manage GuildBotics configuration."""
+    pass
+
+
+@config.command()
 def add() -> None:
     """Add a new member to the GuildBotics project."""
     _load_env_from_cwd()
     get_setup_tool().add_member()
 
 
-@main.command()
+@config.command()
 def init() -> None:
     """Initialize the GuildBotics environment.
 
@@ -262,7 +268,7 @@ def init() -> None:
     get_setup_tool().init_project()
 
 
-@main.command()
+@config.command()
 def verify() -> None:
     """Verify the GuildBotics environment.
 

--- a/guildbotics/cli/simple/locales/cli.en.yml
+++ b/guildbotics/cli/simple/locales/cli.en.yml
@@ -80,8 +80,8 @@ en:
   error_invalid_github_username: "The specified GitHub user does not exist."
   error_invalid_github_apps_url: "Invalid GitHub Apps settings page URL format: https://github.com/organizations/<org>/settings/apps/<app-slug>"
   error_config_dir_not_found: "The specified configuration directory was not found: %{path}"
-  error_project_yml_not_found: "%{path} not found. Please run `guildbotics init` first."
-  error_no_active_member: "No active AI agents registered. Please run `guildbotics add`."
+  error_project_yml_not_found: "%{path} not found. Please run `guildbotics config init` first."
+  error_no_active_member: "No active AI agents registered. Please run `guildbotics config add`."
   error_insufficient_config: "Insufficient configuration for %{person}: %{details}"
 
   sentinel_none: "(Set to none)"

--- a/guildbotics/cli/simple/locales/cli.ja.yml
+++ b/guildbotics/cli/simple/locales/cli.ja.yml
@@ -80,8 +80,8 @@ ja:
   error_invalid_github_username: "指定したGitHubユーザーが存在しません。"
   error_invalid_github_apps_url: "有効なGitHub Appsの設定ページURLの形式: https://github.com/organizations/<org>/settings/apps/<app-slug>"
   error_config_dir_not_found: "指定した設定ディレクトリが見つかりません: %{path}"
-  error_project_yml_not_found: "%{path} が見つかりません。最初に `guildbotics init` を実行してください。"
-  error_no_active_member: "AIエージェントが登録されていません。`guildbotics add` を実行してください"
+  error_project_yml_not_found: "%{path} が見つかりません。最初に `guildbotics config init` を実行してください。"
+  error_no_active_member: "AIエージェントが登録されていません。`guildbotics config add` を実行してください"
   error_insufficient_config: "%{person}の設定に不備があります: %{details}"
 
   sentinel_none: "（未対応にする）"

--- a/guildbotics/templates/intelligences/models/lmstudio/gpt-oss-20b.yml
+++ b/guildbotics/templates/intelligences/models/lmstudio/gpt-oss-20b.yml
@@ -1,0 +1,3 @@
+model_class: agno.models.lmstudio.LMStudio
+parameters:
+  id: gpt-oss-20b


### PR DESCRIPTION
guildbotics CLIのadd, init, verifyをconfigグループのサブコマンドとして再構成する。

新しい呼び出し方:

- guildbotics config init (旧: guildbotics init)
- guildbotics config add (旧: guildbotics add)
- guildbotics config verify (旧: guildbotics verify)
