### PR TITLE
Session 9: macOS arm64 packaging を実機で通す

### DIFF
--- a/.github/workflows/desktop-macos.yml
+++ b/.github/workflows/desktop-macos.yml
@@ -100,20 +100,21 @@ jobs:
           security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
           security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          echo "$APPLE_CERTIFICATE" | base64 --decode > "$RUNNER_TEMP/certificate.p12"
+          echo "$APPLE_CERTIFICATE" | base64 -d > "$RUNNER_TEMP/certificate.p12"
           security import "$RUNNER_TEMP/certificate.p12" \
             -P "$APPLE_CERTIFICATE_PASSWORD" \
             -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
           security set-key-partition-list \
             -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security list-keychain -d user -s "$KEYCHAIN_PATH" login.keychain-db
+          security list-keychains -d user -s "$KEYCHAIN_PATH" login.keychain-db
 
       - name: Build desktop app
         working-directory: desktop
         env:
-          # Tauri only signs when APPLE_SIGNING_IDENTITY / APPLE_CERTIFICATE are
-          # present; empty values produce a valid unsigned build.
-          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          # Only pass the signing identity when the certificate was actually
+          # imported; otherwise an identity set without a certificate would make
+          # Tauri attempt to sign and fail. Empty value produces an unsigned build.
+          APPLE_SIGNING_IDENTITY: ${{ steps.signing.outputs.sign == 'true' && secrets.APPLE_SIGNING_IDENTITY || '' }}
           # Notarization is performed by Tauri only when these are all set.
           APPLE_ID: ${{ steps.signing.outputs.notarize == 'true' && secrets.APPLE_ID || '' }}
           APPLE_PASSWORD: ${{ steps.signing.outputs.notarize == 'true' && secrets.APPLE_PASSWORD || '' }}

--- a/.github/workflows/desktop-macos.yml
+++ b/.github/workflows/desktop-macos.yml
@@ -41,18 +41,83 @@ jobs:
       - name: Build Python app API sidecar
         run: |
           uv run --with pyinstaller python -m PyInstaller \
-            --name guildbotics-app-api \
-            --collect-data guildbotics \
-            --onefile guildbotics/app_api/__main__.py
+            desktop/sidecar/guildbotics-app-api.spec \
+            --noconfirm --clean \
+            --distpath dist --workpath build/sidecar
           mkdir -p desktop/src-tauri/binaries
-          cp dist/guildbotics-app-api desktop/src-tauri/binaries/guildbotics-app-api-aarch64-apple-darwin
+          cp dist/guildbotics-app-api \
+            desktop/src-tauri/binaries/guildbotics-app-api-aarch64-apple-darwin
+
+      - name: Smoke-test sidecar binary
+        run: |
+          desktop/src-tauri/binaries/guildbotics-app-api-aarch64-apple-darwin \
+            --host 127.0.0.1 --port 8765 --token ci-smoke-token &
+          SIDECAR_PID=$!
+          trap 'kill "$SIDECAR_PID" 2>/dev/null || true' EXIT
+          for _ in $(seq 1 30); do
+            if curl -fsS \
+              -H "X-GuildBotics-Session-Token: ci-smoke-token" \
+              http://127.0.0.1:8765/health >/dev/null; then
+              echo "sidecar health check passed"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "sidecar did not become healthy in time" >&2
+          exit 1
 
       - name: Install frontend dependencies
         working-directory: desktop
         run: npm install
 
+      # Optional code signing. When the APPLE_CERTIFICATE secret is absent the
+      # build still succeeds and produces an unsigned DMG.
+      - name: Detect signing secrets
+        id: signing
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+        run: |
+          if [ -n "$APPLE_CERTIFICATE" ]; then
+            echo "sign=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "sign=false" >> "$GITHUB_OUTPUT"
+          fi
+          if [ -n "$APPLE_CERTIFICATE" ] && [ -n "$APPLE_ID" ]; then
+            echo "notarize=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "notarize=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Import Apple signing certificate
+        if: steps.signing.outputs.sign == 'true'
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.APPLE_KEYCHAIN_PASSWORD }}
+        run: |
+          KEYCHAIN_PATH="$RUNNER_TEMP/guildbotics-signing.keychain-db"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          echo "$APPLE_CERTIFICATE" | base64 --decode > "$RUNNER_TEMP/certificate.p12"
+          security import "$RUNNER_TEMP/certificate.p12" \
+            -P "$APPLE_CERTIFICATE_PASSWORD" \
+            -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security set-key-partition-list \
+            -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security list-keychain -d user -s "$KEYCHAIN_PATH" login.keychain-db
+
       - name: Build desktop app
         working-directory: desktop
+        env:
+          # Tauri only signs when APPLE_SIGNING_IDENTITY / APPLE_CERTIFICATE are
+          # present; empty values produce a valid unsigned build.
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          # Notarization is performed by Tauri only when these are all set.
+          APPLE_ID: ${{ steps.signing.outputs.notarize == 'true' && secrets.APPLE_ID || '' }}
+          APPLE_PASSWORD: ${{ steps.signing.outputs.notarize == 'true' && secrets.APPLE_PASSWORD || '' }}
+          APPLE_TEAM_ID: ${{ steps.signing.outputs.notarize == 'true' && secrets.APPLE_TEAM_ID || '' }}
         run: npm run tauri build -- --target aarch64-apple-darwin
 
       - name: Upload desktop artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ MANIFEST
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
 *.spec
+# Keep the desktop sidecar build spec under version control (the macOS
+# packaging workflow builds the Local API sidecar from it).
+!desktop/sidecar/*.spec
 
 # Installer logs
 pip-log.txt

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -1,0 +1,185 @@
+# GuildBotics Desktop (macOS)
+
+GuildBotics の macOS 向けデスクトップ GUI です。Tauri v2 + TypeScript frontend と、Python backend（Local API daemon）を sidecar として同梱します。
+
+- 正式対応: macOS Apple Silicon (arm64)
+- v1 は手動更新前提（自動更新なし）
+- 設計方針の詳細は [../docs/desktop_app_plan.ja.md](../docs/desktop_app_plan.ja.md) を参照
+
+---
+
+## 1. 前提ツール
+
+| ツール | バージョン目安 | 用途 |
+|---|---|---|
+| [uv](https://docs.astral.sh/uv/) | 最新 | Python 依存解決・sidecar build |
+| Node.js | 20 以上（CI は 22） | frontend build / Tauri CLI |
+| Rust (rustup) | **stable 1.85 以上** | Tauri 本体の build |
+| Xcode Command Line Tools | — | macOS 向けリンク・署名 |
+
+### Rust ツールチェーンの注意（重要）
+
+Tauri の依存に `edition2024` を要求するクレートがあるため、**Cargo 1.85 以上**が必要です。Homebrew 版の `rust`（standalone）が PATH 上で `rustup` より優先されていると、古い Cargo が使われて次のエラーで失敗します。
+
+```
+error: failed to download `idna_adapter vX.Y.Z`
+  ...
+  feature `edition2024` is required
+```
+
+対処（いずれか）:
+
+```bash
+# rustup の stable を最新化し、PATH 上で優先されるようにする
+rustup default stable
+rustup update
+rustc --version   # 1.85 以上であることを確認
+
+# arm64 ターゲットを追加
+rustup target add aarch64-apple-darwin
+```
+
+`which -a cargo` で Homebrew 版（`/opt/homebrew/bin/cargo`）が先に来る場合は、ビルド時だけ rustup のツールチェーンを優先させることもできます。
+
+```bash
+PATH="$HOME/.rustup/toolchains/stable-aarch64-apple-darwin/bin:$PATH" \
+  npm run tauri build -- --target aarch64-apple-darwin
+```
+
+---
+
+## 2. 配布物（DMG）のローカルビルド手順
+
+リポジトリのルートで実行します。
+
+### 2.1 Python sidecar（Local API）を build する
+
+GuildBotics は config 経由で brain / command を動的解決するため、PyInstaller の static import graph だけでは不足します。収集設定は [sidecar/guildbotics-app-api.spec](sidecar/guildbotics-app-api.spec) にまとめてあります。
+
+```bash
+# リポジトリルートで実行
+uv sync --extra test --extra dev
+
+uv run --with pyinstaller python -m PyInstaller \
+  desktop/sidecar/guildbotics-app-api.spec \
+  --noconfirm --clean \
+  --distpath dist --workpath build/sidecar
+
+# Tauri sidecar の配置規則に合わせてコピー（ターゲット triple のサフィックスが必須）
+mkdir -p desktop/src-tauri/binaries
+cp dist/guildbotics-app-api \
+  desktop/src-tauri/binaries/guildbotics-app-api-aarch64-apple-darwin
+```
+
+生成される sidecar は onefile で約 200MB 強です。
+
+> **動作確認（任意）**: 配置前に sidecar 単体を起動して health を確認できます。
+>
+> ```bash
+> dist/guildbotics-app-api --host 127.0.0.1 --port 8765 --token dev-token &
+> curl -H "X-GuildBotics-Session-Token: dev-token" http://127.0.0.1:8765/health
+> # => {"status":"ok"}
+> ```
+
+### 2.2 frontend 依存をインストールして DMG を build する
+
+```bash
+cd desktop
+npm install
+npm run tauri build -- --target aarch64-apple-darwin
+```
+
+成果物:
+
+```
+desktop/src-tauri/target/aarch64-apple-darwin/release/bundle/dmg/GuildBotics_<version>_aarch64.dmg
+```
+
+（例: `GuildBotics_0.1.0_aarch64.dmg`。`<version>` は [src-tauri/tauri.conf.json](src-tauri/tauri.conf.json) の `version`）
+
+DMG 内の `GuildBotics.app/Contents/MacOS/` に desktop 本体と sidecar `guildbotics-app-api` が同梱されます。secrets を設定していないローカルビルドは **ad-hoc 署名（実質 unsigned）** です。署名・notarization は次節を参照。
+
+---
+
+## 3. 開発モード（`tauri dev`）
+
+毎回 PyInstaller を build せずに開発したい場合は、sidecar の配置先に「ソースを直接実行する薄いシェルスクリプト」を置くと高速に反復できます。
+
+`desktop/src-tauri/binaries/guildbotics-app-api-aarch64-apple-darwin` を以下の内容で作成し、実行権限を付与します。
+
+```sh
+#!/bin/sh
+set -eu
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(CDPATH= cd -- "$SCRIPT_DIR/../../.." && pwd)"
+cd "$REPO_ROOT"
+if command -v uv >/dev/null 2>&1; then
+  exec uv run --no-sync python -m guildbotics.app_api "$@"
+fi
+exec python3 -m guildbotics.app_api "$@"
+```
+
+```bash
+chmod +x desktop/src-tauri/binaries/guildbotics-app-api-aarch64-apple-darwin
+cd desktop && npm run tauri dev
+```
+
+> `desktop/src-tauri/binaries/` は `.gitignore` 対象です。配布物を作る前には、必ず 2.1 の手順で本物の PyInstaller バイナリへ置き換えてください。
+
+---
+
+## 4. DMG のインストール手順（利用者向け）
+
+1. `GuildBotics_<version>_aarch64.dmg` をダブルクリックしてマウントする。
+2. 開いたウィンドウで **`GuildBotics.app` を `Applications` フォルダへドラッグ**する。
+3. マウントしたディスクイメージを取り出す（Finder のサイドバーで取り出し、または `⌘E`）。
+
+### 初回起動（unsigned / 未 notarized の場合）
+
+ローカルビルドや署名なしの DMG は Gatekeeper にブロックされます。次のいずれかで開きます。
+
+- **方法 A（推奨）**: `Applications` の `GuildBotics.app` を **右クリック → 開く** → 警告ダイアログで再度 **開く**。
+- **方法 B**: 一度起動を試みた後、**システム設定 → プライバシーとセキュリティ** を開き、下部の「"GuildBotics" は…」の項目で **このまま開く** を押す。
+- **方法 C（CLI）**: quarantine 属性を外す。
+
+  ```bash
+  xattr -dr com.apple.quarantine /Applications/GuildBotics.app
+  ```
+
+> signed + notarized された DMG ではこの操作は不要です。
+
+### 起動後
+
+- 初回起動時、アプリは同梱の sidecar（Local API）を起動します。**onefile sidecar の自己展開のため、初回は起動完了まで約 10 秒かかります**（2 回目以降は速くなります）。
+- backend が立ち上がると、設定状態（config / `.env` / storage path）が画面に表示されます。
+
+---
+
+## 5. コード署名・notarization（任意）
+
+CI（[../.github/workflows/desktop-macos.yml](../.github/workflows/desktop-macos.yml)）は、以下の GitHub Secrets が設定されている場合だけ署名・notarization を行います。未設定なら unsigned DMG を生成します。
+
+| Secret | 内容 |
+|---|---|
+| `APPLE_CERTIFICATE` | Developer ID Application 証明書（base64 化した `.p12`） |
+| `APPLE_CERTIFICATE_PASSWORD` | `.p12` のパスワード |
+| `APPLE_KEYCHAIN_PASSWORD` | CI 上の一時 keychain 用パスワード |
+| `APPLE_SIGNING_IDENTITY` | 署名 identity（例: `Developer ID Application: Name (TEAMID)`） |
+| `APPLE_ID` | notarization 用 Apple ID |
+| `APPLE_PASSWORD` | notarization 用 app-specific password |
+| `APPLE_TEAM_ID` | Apple Developer Team ID |
+
+`APPLE_CERTIFICATE` が無ければ署名 step を skip、`APPLE_CERTIFICATE` と `APPLE_ID` が揃った時だけ notarization を実行します。
+
+---
+
+## 6. トラブルシュート
+
+| 症状 | 原因 / 対処 |
+|---|---|
+| `feature 'edition2024' is required` / `idna_adapter` の download 失敗 | Cargo が古い。rustup の stable 1.85+ を使う（§1 参照）。 |
+| `tauri build` で sidecar が見つからない | §2.1 を実行し、`desktop/src-tauri/binaries/guildbotics-app-api-aarch64-apple-darwin` が存在するか確認。 |
+| PyInstaller 実行時に `ModuleNotFoundError` | 動的 import されるモジュールが収集されていない。[sidecar/guildbotics-app-api.spec](sidecar/guildbotics-app-api.spec) の `hiddenimports` / `collect_all` 対象に追加する。 |
+| GUI で PDF 変換（`to_pdf`）が使えない | v1 既知の制約。sidecar は `weasyprint` を同梱しない。PDF が必要な場合は native dependency を入れた CLI を使う。 |
+| 「開発元を確認できません」で起動できない | §4 の初回起動手順（右クリック → 開く / `xattr` で quarantine 解除）。 |
+| 初回起動が遅い | onefile sidecar の自己展開のため。約 10 秒待つ。 |

--- a/desktop/sidecar/guildbotics-app-api.spec
+++ b/desktop/sidecar/guildbotics-app-api.spec
@@ -1,0 +1,79 @@
+# PyInstaller spec for the GuildBotics desktop sidecar (Local API daemon).
+#
+# Built by `.github/workflows/desktop-macos.yml` and reproducible locally with:
+#
+#   uv run --with pyinstaller python -m PyInstaller \
+#       desktop/sidecar/guildbotics-app-api.spec --noconfirm
+#
+# Notes:
+# - GuildBotics resolves brains / commands dynamically from config via
+#   `guildbotics.utils.import_utils.load_class`, so the whole `guildbotics`
+#   package (submodules + data files) must be collected, not just the modules
+#   reachable by PyInstaller's static import graph.
+# - `weasyprint` is intentionally NOT bundled. `ToPdfCommand` imports it lazily
+#   and raises a friendly `CommandError` when its native libraries are missing,
+#   so the sidecar stays buildable without GTK/Pango/Cairo. PDF conversion in
+#   the packaged GUI is a known v1 limitation; the CLI remains the fallback.
+
+from PyInstaller.utils.hooks import collect_all, collect_data_files, collect_submodules
+
+datas = []
+binaries = []
+hiddenimports = []
+
+# Collect the whole guildbotics package (code + templates/locales/assets).
+hiddenimports += collect_submodules("guildbotics")
+datas += collect_data_files("guildbotics")
+
+# Third-party packages that rely on dynamic imports / bundled data files.
+for pkg in (
+    "uvicorn",
+    "fastapi",
+    "starlette",
+    "websockets",
+    "agno",
+    "google.genai",
+    "openai",
+    "anthropic",
+):
+    pkg_datas, pkg_binaries, pkg_hiddenimports = collect_all(pkg)
+    datas += pkg_datas
+    binaries += pkg_binaries
+    hiddenimports += pkg_hiddenimports
+
+a = Analysis(
+    ["../../guildbotics/app_api/__main__.py"],
+    pathex=[],
+    binaries=binaries,
+    datas=datas,
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    # weasyprint is loaded lazily by ToPdfCommand; exclude it so the build does
+    # not fail on missing GTK/Pango/Cairo native libraries.
+    excludes=["weasyprint"],
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name="guildbotics-app-api",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=False,
+    runtime_tmpdir=None,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch="arm64",
+    codesign_identity=None,
+    entitlements_file=None,
+)

--- a/desktop/sidecar/guildbotics-app-api.spec
+++ b/desktop/sidecar/guildbotics-app-api.spec
@@ -15,7 +15,15 @@
 #   so the sidecar stays buildable without GTK/Pango/Cairo. PDF conversion in
 #   the packaged GUI is a known v1 limitation; the CLI remains the fallback.
 
+import os
+
 from PyInstaller.utils.hooks import collect_all, collect_data_files, collect_submodules
+
+# `SPECPATH` is injected by PyInstaller and points at this spec file's directory,
+# so the entry point resolves correctly regardless of the working directory the
+# build is invoked from (the CI workflow runs PyInstaller from the repo root).
+REPO_ROOT = os.path.abspath(os.path.join(SPECPATH, "..", ".."))
+ENTRY_POINT = os.path.join(REPO_ROOT, "guildbotics", "app_api", "__main__.py")
 
 datas = []
 binaries = []
@@ -42,7 +50,7 @@ for pkg in (
     hiddenimports += pkg_hiddenimports
 
 a = Analysis(
-    ["../../guildbotics/app_api/__main__.py"],
+    [ENTRY_POINT],
     pathex=[],
     binaries=binaries,
     datas=datas,

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -1412,6 +1412,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-dialog",
  "tauri-plugin-shell",
+ "uuid",
 ]
 
 [[package]]

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -17,3 +17,4 @@ serde_json = "1.0.150"
 tauri = { version = "=2.11.2", features = [] }
 tauri-plugin-dialog = "=2.2.0"
 tauri-plugin-shell = "=2.2.1"
+uuid = { version = "1", features = ["v4"] }

--- a/desktop/src-tauri/capabilities/default.json
+++ b/desktop/src-tauri/capabilities/default.json
@@ -6,17 +6,6 @@
   "permissions": [
     "core:default",
     "dialog:allow-open",
-    "shell:allow-open",
-    {
-      "identifier": "shell:allow-execute",
-      "allow": [
-        {
-          "name": "binaries/guildbotics-app-api",
-          "cmd": "binaries/guildbotics-app-api",
-          "sidecar": true,
-          "args": true
-        }
-      ]
-    }
+    "shell:allow-open"
   ]
 }

--- a/desktop/src-tauri/gen/schemas/capabilities.json
+++ b/desktop/src-tauri/gen/schemas/capabilities.json
@@ -1,1 +1,1 @@
-{"default":{"identifier":"default","description":"Default permissions for the GuildBotics desktop window.","local":true,"windows":["main"],"permissions":["core:default","dialog:allow-open","shell:allow-open",{"identifier":"shell:allow-execute","allow":[{"args":true,"cmd":"binaries/guildbotics-app-api","name":"binaries/guildbotics-app-api","sidecar":true}]}]}}
+{"default":{"identifier":"default","description":"Default permissions for the GuildBotics desktop window.","local":true,"windows":["main"],"permissions":["core:default","dialog:allow-open","shell:allow-open"]}}

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -77,7 +77,13 @@ pub fn run() {
         .run(|app_handle, event| {
             if let RunEvent::Exit = event {
                 if let Some(state) = app_handle.try_state::<BackendState>() {
-                    if let Some(child) = state.child.lock().unwrap().take() {
+                    // Tolerate a poisoned mutex so the app can still exit cleanly;
+                    // recover the guard and kill the child if one is present.
+                    let mut guard = match state.child.lock() {
+                        Ok(guard) => guard,
+                        Err(poisoned) => poisoned.into_inner(),
+                    };
+                    if let Some(child) = guard.take() {
                         let _ = child.kill();
                     }
                 }

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -1,7 +1,86 @@
+use std::net::TcpListener;
+use std::sync::Mutex;
+
+use tauri::{Manager, RunEvent};
+use tauri_plugin_shell::process::{CommandChild, CommandEvent};
+use tauri_plugin_shell::ShellExt;
+
+/// Holds the Local API sidecar process and the connection details the frontend
+/// needs to talk to it.
+///
+/// The sidecar is spawned once per app process and torn down when the app
+/// exits, so a closed/reopened window reuses the same backend instead of
+/// starting a second one. A freshly picked port avoids colliding with a sidecar
+/// that may have been orphaned by a previous force-quit.
+struct BackendState {
+    token: String,
+    port: u16,
+    child: Mutex<Option<CommandChild>>,
+}
+
+#[tauri::command]
+fn backend_info(state: tauri::State<'_, BackendState>) -> serde_json::Value {
+    serde_json::json!({
+        "port": state.port,
+        "token": state.token,
+    })
+}
+
+/// Reserve a free loopback TCP port by binding to port 0 and reading back the
+/// assigned port. Falls back to the historical default if the probe fails.
+fn pick_free_port() -> u16 {
+    TcpListener::bind("127.0.0.1:0")
+        .ok()
+        .and_then(|listener| listener.local_addr().ok())
+        .map(|addr| addr.port())
+        .unwrap_or(8765)
+}
+
 pub fn run() {
+    let token = uuid::Uuid::new_v4().to_string();
+    let port = pick_free_port();
+
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_shell::init())
-        .run(tauri::generate_context!())
-        .expect("error while running GuildBotics desktop application");
+        .invoke_handler(tauri::generate_handler![backend_info])
+        .setup(move |app| {
+            let port_arg = port.to_string();
+            let (mut rx, child) = app
+                .shell()
+                .sidecar("guildbotics-app-api")?
+                // The sidecar is a PyInstaller one-file binary whose worker can
+                // outlive a killed bootloader. Hand it our PID so it can exit on
+                // its own if this app ever dies without a clean teardown.
+                .env("GUILDBOTICS_APP_API_PARENT_PID", std::process::id().to_string())
+                .args(["--host", "127.0.0.1", "--port", &port_arg, "--token", &token])
+                .spawn()?;
+
+            // Keep the child's stdout/stderr pipe drained so it never blocks.
+            tauri::async_runtime::spawn(async move {
+                while let Some(event) = rx.recv().await {
+                    if let CommandEvent::Terminated(_) = event {
+                        break;
+                    }
+                }
+            });
+
+            app.manage(BackendState {
+                token,
+                port,
+                child: Mutex::new(Some(child)),
+            });
+            Ok(())
+        })
+        .build(tauri::generate_context!())
+        .expect("error while building GuildBotics desktop application")
+        .run(|app_handle, event| {
+            if let RunEvent::Exit = event {
+                if let Some(state) = app_handle.try_state::<BackendState>() {
+                    if let Some(child) = state.child.lock().unwrap().take() {
+                        let _ = child.kill();
+                    }
+                }
+            }
+        });
 }

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -26,6 +26,13 @@
   "bundle": {
     "active": true,
     "targets": ["dmg"],
+    "icon": [
+      "icons/32x32.png",
+      "icons/128x128.png",
+      "icons/128x128@2x.png",
+      "icons/icon.icns",
+      "icons/icon.ico"
+    ],
     "externalBin": ["binaries/guildbotics-app-api"],
     "macOS": {
       "minimumSystemVersion": "13.0"

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -124,11 +124,24 @@ export function App() {
           <Route element={<CommandsPage />} path="/commands" />
           <Route element={<DiagnosticsPage />} path="/diagnostics" />
           <Route element={<SetupPage />} path="/setup" />
-          <Route element={<Navigate replace to="/service" />} path="*" />
+          <Route element={<IndexRedirect />} path="*" />
         </Routes>
       </section>
     </main>
   );
+}
+
+function IndexRedirect() {
+  // The landing route picks the first screen based on whether setup is done:
+  // a configured workspace opens the service screen, otherwise the setup screen.
+  const config = useQuery({ queryKey: ["config"], queryFn: getConfigStatus });
+  if (config.isLoading) {
+    return null;
+  }
+  const configured = Boolean(
+    config.data?.primary_project_file_exists || config.data?.home_project_file_exists,
+  );
+  return <Navigate replace to={configured ? "/service" : "/setup"} />;
 }
 
 function ServicePage() {

--- a/desktop/src/api/backend.ts
+++ b/desktop/src/api/backend.ts
@@ -1,24 +1,25 @@
-import { configureApi, setWorkspace } from "./client";
+import { configureApi, getApiBase, setWorkspace } from "./client";
 
-const API_BASE = import.meta.env.VITE_GUILDBOTICS_API_BASE ?? "http://127.0.0.1:8765";
 const STATIC_TOKEN = import.meta.env.VITE_GUILDBOTICS_API_TOKEN ?? "";
+const STATIC_BASE = import.meta.env.VITE_GUILDBOTICS_API_BASE ?? "http://127.0.0.1:8765";
 
-let backendProcess: { kill(): Promise<void> } | null = null;
 let currentWorkspace = localStorage.getItem("guildbotics.workspace") ?? "";
 
+/**
+ * Connect the frontend to the Local API backend.
+ *
+ * The sidecar process is owned by the Tauri (Rust) host: it is spawned once per
+ * app process and killed when the app exits. The frontend only discovers the
+ * port + session token via the `backend_info` command and reuses that running
+ * backend. This avoids starting a second sidecar (and the resulting session
+ * token / port collision) when a closed window is reopened.
+ */
 export async function startBackend() {
-  const token = STATIC_TOKEN || crypto.randomUUID();
-  configureApi(token);
-
+  // Dev / browser preview: the backend is started externally with a fixed token.
   if (STATIC_TOKEN) {
-    await waitForHealth(token);
-    if (currentWorkspace) {
-      try {
-        await applyWorkspace(currentWorkspace);
-      } catch (error) {
-        console.warn("Unable to restore GuildBotics workspace", error);
-      }
-    }
+    configureApi(STATIC_TOKEN, STATIC_BASE);
+    await waitForHealth(STATIC_TOKEN);
+    await restoreWorkspace();
     return;
   }
 
@@ -26,33 +27,38 @@ export async function startBackend() {
     throw new Error("GuildBotics backend is not configured for browser preview.");
   }
 
-  const { Command } = await import("@tauri-apps/plugin-shell");
-  const command = Command.sidecar("binaries/guildbotics-app-api", [
-    "--host",
-    "127.0.0.1",
-    "--port",
-    "8765",
-    "--token",
-    token,
-  ], currentWorkspace ? { cwd: currentWorkspace } : undefined);
-  backendProcess = await command.spawn();
-  await waitForHealth(token);
+  const { invoke } = await import("@tauri-apps/api/core");
+  const info = await invoke<{ port: number; token: string }>("backend_info");
+  configureApi(info.token, `http://127.0.0.1:${info.port}`);
+  await waitForHealth(info.token);
+  await restoreWorkspace();
 }
 
+/**
+ * Switch the workspace the backend operates in. The backend changes its working
+ * directory at runtime via `POST /workspace`, so there is no need to restart the
+ * sidecar (which would orphan the previous process).
+ */
 export async function restartBackend(workspace: string) {
   localStorage.setItem("guildbotics.workspace", workspace);
   currentWorkspace = workspace;
-  if (STATIC_TOKEN) {
-    await applyWorkspace(workspace);
-    return;
-  }
-  await stopBackend();
-  await startBackend();
+  await applyWorkspace(workspace);
 }
 
 export async function stopBackend() {
-  await backendProcess?.kill();
-  backendProcess = null;
+  // The sidecar lifecycle is owned by the Rust host (killed on app exit), so
+  // there is nothing for the frontend to tear down here.
+}
+
+async function restoreWorkspace() {
+  if (!currentWorkspace) {
+    return;
+  }
+  try {
+    await applyWorkspace(currentWorkspace);
+  } catch (error) {
+    console.warn("Unable to restore GuildBotics workspace", error);
+  }
 }
 
 async function applyWorkspace(workspace: string) {
@@ -70,11 +76,16 @@ function isTauriRuntime() {
 }
 
 async function waitForHealth(token: string) {
-  const deadline = Date.now() + 15_000;
+  // The packaged sidecar is a PyInstaller one-file binary that unpacks itself
+  // into a temp dir on first launch, which can take ~10s on a fresh Mac before
+  // uvicorn answers. Keep a generous deadline so the cold start is not flagged
+  // as a backend failure.
+  const deadline = Date.now() + 45_000;
+  const base = getApiBase();
   let lastError: unknown = null;
   while (Date.now() < deadline) {
     try {
-      const response = await fetch(`${API_BASE}/health`, {
+      const response = await fetch(`${base}/health`, {
         headers: { "X-GuildBotics-Session-Token": token },
       });
       if (response.ok) {

--- a/desktop/src/api/client.ts
+++ b/desktop/src/api/client.ts
@@ -1,8 +1,15 @@
-const API_BASE = import.meta.env.VITE_GUILDBOTICS_API_BASE ?? "http://127.0.0.1:8765";
+let apiBase = import.meta.env.VITE_GUILDBOTICS_API_BASE ?? "http://127.0.0.1:8765";
 let sessionToken = import.meta.env.VITE_GUILDBOTICS_API_TOKEN ?? "";
 
-export function configureApi(token: string) {
+export function configureApi(token: string, baseUrl?: string) {
   sessionToken = token;
+  if (baseUrl) {
+    apiBase = baseUrl;
+  }
+}
+
+export function getApiBase(): string {
+  return apiBase;
 }
 
 export type ConfigStatus = {
@@ -609,7 +616,7 @@ async function request<T>(
   path: string,
   options: { method?: string; body?: unknown } = {},
 ): Promise<T> {
-  const response = await fetch(`${API_BASE}${path}`, {
+  const response = await fetch(`${apiBase}${path}`, {
     method: options.method ?? "GET",
     headers: {
       "Content-Type": "application/json",
@@ -644,7 +651,7 @@ async function readError(response: Response): Promise<ApiErrorPayload> {
 }
 
 function websocketBase(): string {
-  const url = new URL(API_BASE);
+  const url = new URL(apiBase);
   url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
   return url.toString().replace(/\/$/, "");
 }

--- a/desktop/src/i18n.ts
+++ b/desktop/src/i18n.ts
@@ -20,6 +20,12 @@ const resources = {
           english: "English",
           japanese: "Japanese",
         },
+        loading: {
+          title: "Starting GuildBotics",
+          body: "Connecting to the local backend. The first launch can take a little longer while it gets ready.",
+          failed: "GuildBotics could not start",
+          retry: "Retry",
+        },
       },
       service: {
         title: "Service Runtime",
@@ -799,6 +805,12 @@ const resources = {
           label: "表示言語",
           english: "English",
           japanese: "日本語",
+        },
+        loading: {
+          title: "GuildBotics を起動しています",
+          body: "ローカルバックエンドに接続しています。初回起動は準備のため少し時間がかかることがあります。",
+          failed: "GuildBotics を起動できませんでした",
+          retry: "再試行",
         },
       },
       setup: {

--- a/desktop/src/main.tsx
+++ b/desktop/src/main.tsx
@@ -1,8 +1,19 @@
-import React from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import ReactDOM from "react-dom/client";
-import { MantineProvider, createTheme } from "@mantine/core";
+import {
+  Alert,
+  Button,
+  Center,
+  Loader,
+  MantineProvider,
+  Stack,
+  Text,
+  Title,
+  createTheme,
+} from "@mantine/core";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { HashRouter } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 
 import { App } from "./App";
 import { startBackend, stopBackend } from "./api/backend";
@@ -16,26 +27,69 @@ const theme = createTheme({
   defaultRadius: "md",
 });
 
-startBackend()
-  .then(() => {
-    ReactDOM.createRoot(document.getElementById("root")!).render(
-      <React.StrictMode>
-        <MantineProvider theme={theme}>
-          <QueryClientProvider client={queryClient}>
-            <HashRouter>
-              <App />
-            </HashRouter>
-          </QueryClientProvider>
-        </MantineProvider>
-      </React.StrictMode>,
+type BootStatus =
+  | { state: "loading" }
+  | { state: "ready" }
+  | { state: "error"; message: string };
+
+function Bootstrap() {
+  const { t } = useTranslation();
+  const [status, setStatus] = useState<BootStatus>({ state: "loading" });
+
+  const connect = useCallback(() => {
+    setStatus({ state: "loading" });
+    startBackend()
+      .then(() => setStatus({ state: "ready" }))
+      .catch((error: unknown) => setStatus({ state: "error", message: String(error) }));
+  }, []);
+
+  useEffect(() => {
+    connect();
+  }, [connect]);
+
+  if (status.state === "ready") {
+    return (
+      <HashRouter>
+        <App />
+      </HashRouter>
     );
-  })
-  .catch((error: unknown) => {
-    const message = document.createElement("pre");
-    message.className = "startup-error";
-    message.textContent = String(error);
-    document.body.replaceChildren(message);
-  });
+  }
+
+  return (
+    <Center className="app-bootstrap">
+      {status.state === "loading" ? (
+        <Stack align="center" gap="md" maw={420}>
+          <Loader size="lg" />
+          <Title order={3}>{t("app.loading.title")}</Title>
+          <Text c="dimmed" ta="center">
+            {t("app.loading.body")}
+          </Text>
+        </Stack>
+      ) : (
+        <Alert color="red" title={t("app.loading.failed")} maw={520}>
+          <Stack gap="sm">
+            <Text size="sm" style={{ whiteSpace: "pre-wrap" }}>
+              {status.message}
+            </Text>
+            <Button variant="light" onClick={connect}>
+              {t("app.loading.retry")}
+            </Button>
+          </Stack>
+        </Alert>
+      )}
+    </Center>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <MantineProvider theme={theme}>
+      <QueryClientProvider client={queryClient}>
+        <Bootstrap />
+      </QueryClientProvider>
+    </MantineProvider>
+  </React.StrictMode>,
+);
 
 window.addEventListener("beforeunload", () => {
   void stopBackend();

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -777,6 +777,11 @@ pre {
   margin: 24px;
 }
 
+.app-bootstrap {
+  min-height: 100vh;
+  padding: 24px;
+}
+
 .status {
   color: #7a4f00;
   font-weight: 700;

--- a/docs/desktop_app_plan.ja.md
+++ b/docs/desktop_app_plan.ja.md
@@ -138,7 +138,7 @@ frontend は `message` を表示し、分岐や復旧導線には `code` と `co
 - Setup UI から GitHub 未設定の fresh workspace に project config と `.env` を生成できることを確認済み。
 - frontend API client に `WS /events` の subscription helper を追加し、command runner 画面で実行イベントを表示するようにした。
 - `desktop/src/api/backend.ts` で Tauri sidecar 起動と health check の入口を追加済み。
-- `.github/workflows/desktop-macos.yml` に macOS arm64 desktop artifact build の骨格を追加済み。
+- `.github/workflows/desktop-macos.yml` に macOS arm64 desktop artifact build を実装済み。`desktop/sidecar/guildbotics-app-api.spec` ベースで PyInstaller sidecar を build し、sidecar health smoke test、optional な signing / notarization step を経て `tauri build` で DMG を生成する。secrets 未設定なら unsigned DMG、secrets 設定済みなら signed + notarized DMG を生成する。ローカル実機で unsigned DMG 生成まで検証済み。
 - `to_pdf` の WeasyPrint import を実行時 lazy import にし、PDF を使わない command 実行が native dependency 不足に巻き込まれないようにした。
 - `GET /config/intelligences` と `PUT /config/intelligences` を追加し、チーム既定と member override の `model_mapping.yml` / `brain_mapping.yml` / `cli_agent_mapping.yml` / `models/*` / `cli_agents/*` を GUI から読み書きできるようにした。
 - Setup UI の `LLM・CLIエージェント` 詳細設定から「準備中」表示を削除し、機能割り当て、モデル定義、CLI エージェント定義を編集できるようにした。
@@ -149,7 +149,8 @@ frontend は `message` を表示し、分岐や復旧導線には `code` と `co
 - `POST /verify` は GUI 向けの軽量・非対話 check として実装済み。既存 `config verify` と異なり、外部サービス変更や対話 prompt は行わない。
 - `POST /scheduler/stop` は v1 では sidecar 内 runtime 全体を停止する。個別 runtime の停止 UI は未実装。
 - `WS /logs` は global log stream の skeleton であり、UI 統合は未整備。
-- macOS signing / notarization secrets は未設定。
+- macOS signing / notarization secrets は未設定。workflow は secrets 未設定時に unsigned DMG を生成する。secrets 名は `APPLE_CERTIFICATE` / `APPLE_CERTIFICATE_PASSWORD` / `APPLE_KEYCHAIN_PASSWORD` / `APPLE_SIGNING_IDENTITY` / `APPLE_ID` / `APPLE_PASSWORD` / `APPLE_TEAM_ID`。
+- packaged GUI sidecar は `weasyprint` を同梱しないため、`to_pdf` 系の PDF 変換は GUI からは使えない（native dependency を入れた CLI が fallback）。sidecar は PyInstaller onefile のため初回起動時の自己展開に約 10 秒かかる。
 - local full pytest は WeasyPrint native dependency がない環境では `tests/guildbotics/drivers/commands/test_to_pdf_command.py` が失敗する。
 
 ## セッション分割 TODO
@@ -710,6 +711,8 @@ uv run --no-sync pylint guildbotics
 
 ### Session 9: macOS arm64 packaging を実際に通す
 
+状態: 完了。
+
 目的:
 
 - Mac Apple Silicon 用の desktop artifact を CI で生成できるようにする。
@@ -727,6 +730,30 @@ uv run --no-sync pylint guildbotics
 - GitHub Actions の manual run で unsigned DMG artifact が生成される。
 - secrets 設定済み環境では signed + notarized DMG が生成される。
 - fresh Mac で app 起動、backend health、config status 表示まで確認できる。
+
+Session 9 完了メモ（2026-06-03）:
+
+- PyInstaller の sidecar build を再現可能にするため、`desktop/sidecar/guildbotics-app-api.spec` を追加した。`guildbotics` package は config 経由で brain / command を動的解決する（`load_class`）ため、静的 import graph に依存せず submodule と data file をまとめて収集する。`.gitignore` の `*.spec` 除外に対して `!desktop/sidecar/*.spec` の例外を追加し、spec を version control に含めた。
+- `weasyprint` は spec の `excludes` で sidecar に含めない方針とした。`ToPdfCommand` は実行時 lazy import で、native lib 不在時は `CommandError` を返すため、GTK / Pango / Cairo を持たない CI でも sidecar が build できる。packaged GUI の PDF 変換は v1 既知の制約とし、native dependency を入れた CLI を fallback とする。
+- `.github/workflows/desktop-macos.yml` を更新し、(1) spec ベースの sidecar build、(2) build 直後の sidecar health smoke test、(3) signing / notarization の optional step、(4) `tauri build` を実行する。secrets 未設定でも unsigned DMG が生成される。
+- signing / notarization 用 secrets 名を確定した: `APPLE_CERTIFICATE`（base64 .p12）、`APPLE_CERTIFICATE_PASSWORD`、`APPLE_KEYCHAIN_PASSWORD`、`APPLE_SIGNING_IDENTITY`、`APPLE_ID`、`APPLE_PASSWORD`（app-specific password）、`APPLE_TEAM_ID`。`APPLE_CERTIFICATE` が無ければ signing step を skip、`APPLE_CERTIFICATE` と `APPLE_ID` が揃った時だけ notarization 用 env を渡す。Tauri は env が空なら unsigned build を生成する。
+- onefile sidecar は初回起動時に temp dir へ自己展開するため cold start に約 10 秒かかる。`desktop/src/api/backend.ts` の health 待ち deadline を 15 秒から 45 秒へ広げ、fresh Mac の初回起動を backend 起動失敗扱いにしないようにした。
+- ローカル実機検証（macOS Apple Silicon, 2026-06-03）:
+  - `desktop/sidecar/guildbotics-app-api.spec` から PyInstaller onefile（約 212MB）を build 成功。
+  - build した sidecar を直接起動し、`GET /health` が `{"status":"ok"}`、`GET /config/status` が cwd / config path を正しく返すことを確認（cwd を workspace として扱う設計が packaged binary でも機能）。
+  - `npm run tauri build -- --target aarch64-apple-darwin` で unsigned DMG（`GuildBotics_0.1.0_aarch64.dmg`, 約 215MB）を生成。DMG 内の `GuildBotics.app/Contents/MacOS/` に desktop 本体と sidecar `guildbotics-app-api` が同梱され、ad-hoc 署名であることを確認。
+  - 注意: ローカルの `cargo` は Homebrew 版 1.83 が PATH 優先になっていると `edition2024` 要求の依存解決に失敗する。rustup の stable toolchain（1.85 以降）を使う必要がある。CI runner (macos-14) の既定 toolchain は要件を満たす。
+- インストール後の起動検証で 2 件の packaging bug を修正した:
+  - **アプリアイコン**: `tauri.conf.json` の `bundle` に `icon` 指定が無く、Tauri 組み込みのデフォルトアイコンが使われていた。`icons/*.png` / `icon.icns`（GuildBotics アイコン）を `bundle.icon` に明示した。
+  - **sidecar 起動の ACL**: 当初 frontend が `Command.sidecar(...).spawn()` で sidecar を起動しており、capability が `shell:allow-execute` のみで `Command plugin:shell|spawn not allowed by ACL` になっていた。後述の lifecycle 再設計で sidecar 起動を Rust 側へ移したため、frontend からの shell spawn 自体を廃止し、capability は `shell:allow-open` のみに戻した（Rust 内からの sidecar spawn は ACL の対象外）。
+- インストール後の再起動検証で sidecar lifecycle のバグを修正した（`ウインドウを閉じて再起動すると invalid_session_token になる`）:
+  - **原因**: sidecar 起動が frontend にあり、(1) macOS ではウィンドウを閉じてもアプリが Dock に残り、JS spawn した sidecar がアプリ終了後も orphan 化する、(2) window 再表示のたびに新しいトークンで固定ポート 8765 に別 sidecar を起動しようとし、orphan とポート競合 → 古い sidecar が古いトークンで応答 → `invalid_session_token`。
+  - **修正**: sidecar lifecycle を Rust（`desktop/src-tauri/src/lib.rs`）へ移管。アプリプロセスごとに 1 度だけ起動し、`RunEvent::Exit` で kill する。ポートは固定 8765 ではなく起動時に空きポートを動的取得し、orphan 衝突を回避する。frontend（`desktop/src/api/backend.ts`）は `backend_info` command で port / token を取得して既存バックエンドを再利用し、window 再表示で二重起動しない。workspace 切替は sidecar 再起動ではなく実行時 `POST /workspace` に統一した。
+  - **PyInstaller onefile の orphan 対策**: onefile は bootloader が実 worker を子プロセスとして起動するため、bootloader だけを kill しても worker が port を握ったまま残る。sidecar に親 PID 監視 watchdog（`GUILDBOTICS_APP_API_PARENT_PID`、`guildbotics/app_api/server.py`）を追加し、Rust が渡したアプリ PID が消えたら worker 自身も終了するようにした。CLI 実行時は env 未設定のため watchdog は無効。
+  - **実機検証**: 起動 → ウィンドウを閉じる → 再起動でバックエンド再利用（listen port 1 つ、`invalid_session_token` 解消）、通常終了で orphan ゼロ・ポート解放、アプリ SIGKILL（クラッシュ相当）でも watchdog が約 3 秒で sidecar を回収することを確認した。
+- 起動 UX を 2 点改善した:
+  - **起動中の白画面解消**: backend health 待ちの間（onefile cold start で約 10 秒）にこれまで白画面だったのを、`desktop/src/main.tsx` の `Bootstrap` でローダー + 起動メッセージを表示し、失敗時は理由と再試行ボタンを出すようにした。
+  - **未設定時の初期画面**: 初期表示ルートを設定状態で分岐し、project config 未作成なら `サービス実行` ではなく `設定` 画面（`/setup`）を開くようにした（`desktop/src/App.tsx` の `IndexRedirect`）。fresh workspace で `config/status` の `primary/home_project_file_exists` がともに false のとき `/setup` に遷移することを実機確認した。
 
 確認:
 

--- a/guildbotics/app_api/server.py
+++ b/guildbotics/app_api/server.py
@@ -3,10 +3,57 @@ from __future__ import annotations
 import argparse
 import os
 import secrets
+import threading
+import time
 
 import uvicorn
 
 from guildbotics.app_api.api import create_app
+
+
+def _parent_is_alive(parent_pid: int) -> bool:
+    try:
+        os.kill(parent_pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # The process exists but is owned by someone else; treat as alive.
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def _watch_parent(parent_pid: int) -> None:
+    """Exit the sidecar once the parent (desktop app) process is gone.
+
+    The packaged sidecar is a PyInstaller one-file binary, so the desktop host
+    actually spawns a bootloader process that re-executes the real worker as a
+    child. Killing the bootloader does not reliably terminate that worker, which
+    would otherwise survive as an orphan holding the API port. Watching the
+    desktop app PID directly covers both a clean quit and a force-kill of the
+    app.
+    """
+    while True:
+        if not _parent_is_alive(parent_pid):
+            os._exit(0)
+        time.sleep(1.0)
+
+
+def _start_parent_watchdog() -> None:
+    raw_pid = os.getenv("GUILDBOTICS_APP_API_PARENT_PID")
+    if not raw_pid:
+        return
+    try:
+        parent_pid = int(raw_pid)
+    except ValueError:
+        return
+    if parent_pid <= 1:
+        return
+    thread = threading.Thread(
+        target=_watch_parent, args=(parent_pid,), name="parent-watchdog", daemon=True
+    )
+    thread.start()
 
 
 def main() -> None:
@@ -15,6 +62,8 @@ def main() -> None:
     parser.add_argument("--port", type=int, default=8765)
     parser.add_argument("--token", default=os.getenv("GUILDBOTICS_APP_API_TOKEN"))
     args = parser.parse_args()
+
+    _start_parent_watchdog()
 
     token = args.token or secrets.token_urlsafe(32)
     print(f"GUILDBOTICS_APP_API_TOKEN={token}", flush=True)


### PR DESCRIPTION
## 概要

`docs/desktop_app_plan.ja.md` の Session 9（macOS arm64 packaging）を実装し、ローカル実機で DMG のビルド〜起動まで通しました。インストール後テストで見つかった不具合（アイコン未設定、sidecar 起動 ACL、再起動時の `invalid_session_token`、起動 UX）もあわせて修正しています。

## 変更点

### Packaging (Session 9)
- `desktop/sidecar/guildbotics-app-api.spec`: PyInstaller の再現可能な build spec を追加。`guildbotics` は config 経由で brain/command を動的解決するため submodule + data file をまとめて収集。`weasyprint` は lazy import のため bundle しない（PDF 変換は v1 既知の制約、CLI が fallback）。
- `.github/workflows/desktop-macos.yml`: spec ベースの sidecar build → sidecar health smoke test → optional な signing/notarization step → `tauri build`。secrets 未設定なら unsigned DMG、設定済みなら signed + notarized DMG。
- signing/notarization secrets 名を確定（`APPLE_CERTIFICATE` / `APPLE_CERTIFICATE_PASSWORD` / `APPLE_KEYCHAIN_PASSWORD` / `APPLE_SIGNING_IDENTITY` / `APPLE_ID` / `APPLE_PASSWORD` / `APPLE_TEAM_ID`）。
- `desktop/README.md` を追加（ローカルビルド手順・前提・トラブルシュート・DMG インストール手順）。

### インストール後テストで見つかった修正
- **アイコン**: `tauri.conf.json` に `bundle.icon` を追加（デフォルトアイコン → GuildBotics アイコン）。
- **sidecar lifecycle**: sidecar 起動を Rust 側へ移管（`lib.rs`）。アプリプロセスごとに 1 度だけ起動し `RunEvent::Exit` で kill、**動的フリーポート**を使用。frontend は `backend_info` command で port/token を取得して既存バックエンドを**再利用**（`backend.ts` / `client.ts`）。これで「ウインドウを閉じて再起動すると `invalid_session_token`」を解消。
- **onefile orphan 対策**: 親 PID 監視 watchdog を sidecar に追加（`server.py`）。アプリが消えたら sidecar も終了（CLI 実行時は env 未設定で無効）。
- frontend が shell spawn を使わなくなったため capability を `shell:allow-open` のみに整理。

### 起動 UX
- 起動中の白画面をローダー + メッセージ + 失敗時 retry に置換（`main.tsx` の `Bootstrap`）。
- 初期表示ルートを設定状態で分岐し、**未設定なら「設定」画面**を開く（`App.tsx` の `IndexRedirect`）。

## 検証（ローカル実機 / macOS Apple Silicon）
- `npm run tauri build -- --target aarch64-apple-darwin` で unsigned DMG 生成、`.app` に sidecar 同梱・正しいアイコン・ad-hoc 署名を確認。
- sidecar 単体で `/health` `/config/status` が正常応答。
- 起動 → ウィンドウを閉じる → 再起動でバックエンド再利用（listen port 1 つ、`invalid_session_token` 解消）。
- 通常終了で orphan ゼロ・ポート解放、アプリ SIGKILL でも watchdog が約 3 秒で sidecar 回収。
- fresh workspace（未設定）起動で `/setup` に遷移することを確認。
- `npm run build` / `ruff` / `mypy` クリーン、app_api テスト 44 件パス。

> 注: ローカルビルドには rustup stable 1.85+ が必要（Homebrew rust 1.83 が PATH 優先だと `edition2024` で失敗）。CI runner (macos-14) の既定 toolchain は要件を満たす。

🤖 Generated with [Claude Code](https://claude.com/claude-code)