### PR TITLE
test: backend / desktop / E2E のカバレッジ拡充 + テスト戦略ドキュメント整備

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,18 @@ cd desktop
 npm run quality
 ```
 
+Playwright E2E（実ブラウザ + 実 Local API backend。`npm run quality` / 通常 push CI には含めない）:
+
+```bash
+cd desktop
+npm ci
+npm run e2e:install   # 初回のみ: chromium を取得
+npm run e2e           # desktop/e2e/*.spec.ts を headless chromium で実行
+```
+
+- harness（`desktop/e2e/start-stack.mjs`）が backend を `uv run python -m guildbotics.app_api` で temp workspace 起動するため、事前にリポジトリルートで `uv sync --extra test --extra dev` 済みであること。
+- 詳細・journey 一覧は `desktop/README.md` の「テスト」節と `docs/test_gap_analysis.ja.md` を参照。
+
 エージェント作業時の品質確認:
 
 - Python コードを変更したら、原則として `ruff` と `mypy` と関連 `pytest` を実行してから完了報告する
@@ -170,6 +182,8 @@ desktop TypeScript 開発時の品質確認:
 - 純粋関数、入力変換、API payload 生成、trace / scheduler 表示ロジックなどの分岐を変更した場合は Vitest のユニットテストを追加・更新する
 - 重複コード抑止は `npm run duplicates` (`jscpd`) を使う。重複検出を避けるためだけの不自然な分割ではなく、UI とロジックの責務が自然に分かれる形へ整理する
 - Tauri / Rust 側や生成物を frontend 品質チェックへ巻き込まない。対象は `desktop/src` と frontend 設定ファイルを基本とする
+- 実ブラウザ + 実 backend を貫く critical user journey（setup→作成 / scheduler start-stop / command 実行+ストリーム / diagnostics / backend down→retry）を変更したら、`desktop/e2e/*.spec.ts` の該当 Playwright journey を更新する。E2E は `npm run quality` / push CI には含めず、`npm run e2e` で実行する
+- E2E に振る舞いパターンを総当たりで持ち込まない。分岐網羅は Vitest の unit / component（mock 境界）に置き、Playwright は jsdom では検証できない実ブラウザ + 実ワイヤ契約（`client.ts ↔ FastAPI ↔ EventBus`）+ 実ファイル書き込みに絞る
 
 ## テスト実装の考え方
 
@@ -179,7 +193,8 @@ desktop TypeScript 開発時の品質確認:
 
 - Unit test を最も厚くする。純粋関数、入力変換、validator、payload 生成、状態遷移、エラー変換、ファイル解決順はまず unit test で網羅する
 - Component / service integration test は、UI 操作、API endpoint、config 書き込み、runtime lifecycle など境界をまたぐ主要 workflow に限定して追加する
-- E2E / packaging smoke は少数に保つ。backend/frontend 接続、sidecar 起動、代表的 happy path と critical failure path を検証する
+- ブラウザ E2E（Playwright, `desktop/e2e/`）は lean-but-real。実ブラウザ engine + 実 Local API backend でしか検証できない critical user journey（setup→実ファイル書き込み、scheduler start/stop、command 実行+`/events` ストリーム、diagnostics、backend down→retry）に絞り、振る舞いパターンの総当たりはしない（分岐網羅は unit / component に委譲）。push CI からは隔離し専用ジョブで回す
+- Tauri ネイティブ / packaging smoke は最小限に保ち、実 OS + Tauri runtime が要るもの（sidecar 起動 / `backend_info` / file picker など）は workflow_dispatch / release workflow に隔離する
 - LLM、GitHub、Slack、外部 CLI などへの実通信は通常 CI のテストに入れない。既存抽象化、stub、mock、fixture を使い、送信 payload、判定結果、エラー処理を検証する
 - snapshot のみで品質を担保しない。ユーザーが観測する文言・状態、生成 request、保存 file/env、publish event、return value を具体的に assert する
 - テストコードも本体コードと同じ品質対象とする。重複 fixture や場当たり的 mock が増えた場合は helper / factory へ整理する
@@ -193,6 +208,7 @@ desktop TypeScript 開発時の品質確認:
 - desktop の API client を変更したら、URL、method、header、body、query parameter、error response、websocket status を検証する
 - desktop の React component を変更したら、React Testing Library でユーザー操作と表示状態を検証する。implementation detail の state ではなく role/text/value/payload を assert する
 - desktop の setup / commands / diagnostics / service runtime の workflow を変更したら、component test または mock API integration test を追加・更新する
+- desktop の cross-boundary user journey（実 backend を貫く setup / runtime / commands / diagnostics / 起動失敗）を変更したら、`desktop/e2e/` の該当 Playwright spec を追加・更新する（実ブラウザ + 実 backend で検証。総当たりはせず代表 journey に絞る）
 - i18n 文言や翻訳キーを変更したら、キー経由の検証を行い、片方の言語だけ欠落しないことを確認する
 - bug fix では、先に再現テストまたは同等の failing assertion を追加し、そのテストが修正後に通ることを確認する
 

--- a/CONTRIBUTING.ja.md
+++ b/CONTRIBUTING.ja.md
@@ -1,25 +1,39 @@
 # Contributing Guidelines
 
-## Project Structure & Module Organization
-- `guildbotics/`: コアパッケージ。キーとなるモジュールには `drivers/` (スケジューラー)、`workflows/` (タスクオーケストレーション)、`intelligences/` (ブレイン)、`integrations/`、`loader/`、`runtime/`、`entities/`、`utils/`、`templates/` が含まれます。
-- `tests/`: Pytestスイート。ユニットテストは `tests/guildbotics/` の下でパッケージパスをミラーリング；統合テストは `tests/it/` にあり、サンプル設定は `tests/it/config/` にあります。
-- `docs/`: アーキテクチャとデザイン (`docs/ARCHITECTURE.*.md`)。
-- `main.py`: スケジューラーを実行するためのエントリーポイント。
-- `.env`, `.env.example`: ローカル設定。
+本ドキュメントは**人間のコントリビューションプロセス**を扱います。リポジトリ構造・環境構築・CI 相当の build/test/lint コマンド・コーディング標準・テスト戦略については、以下を**正典（single source of truth）**とします。これらは CI と同期して常に最新化されるため、本ファイルでは重複保持しません（重複起因の陳腐化を防ぐため）。
 
-## Build, Test, and Development Commands
-- CI 相当の依存関係を同期: `uv sync --extra test --extra dev`
-- Lint 実行: `uv run --no-sync ruff check guildbotics`
-- 型チェック実行: `uv run --no-sync mypy guildbotics`
-- テスト実行とカバレッジレポート作成: `uv run --no-sync python -m pytest tests/ --cov=guildbotics --cov-report=xml`  (生成物: `coverage.xml`)。
-- ローカル確認の推奨順序: `ruff` -> `mypy` -> `pytest`
+- **`AGENTS.md`** — リポジトリ作業ガイド: モジュール構成、設定解決、CLI、CI 相当コマンド、テスト戦略。
+- **`desktop/README.md`** — desktop アプリの build / 開発 / テスト（Vitest unit/component + Playwright E2E）。
+- **`.github/workflows/ci.yml`** — CI が実際に実行するチェック。
 
-注: このリポジトリは固定された依存ファイル `pyproject.toml` を提供します。uv を使用して必要なライブラリを `uv sync` でインストールしてください。
+テストは `tests/guildbotics/` 配下にパッケージ構成をミラーして配置します（`tests/it/` という別ツリーは存在しません）。CLI のエントリーポイントは `guildbotics`（`guildbotics.cli:main`）で、`main.py` はありません。
+
+## PR を出す前に — CI 相当のチェックを実行する
+
+正典の一覧は `AGENTS.md`（「開発時の基本コマンド（CI 準拠）」）にあります。クイックリファレンス:
+
+```bash
+# Python（リポジトリルート）
+uv sync --extra test --extra dev
+uv run --no-sync ruff format --check guildbotics
+uv run --no-sync ruff check guildbotics
+uv run --no-sync mypy guildbotics
+uv run --no-sync pylint guildbotics
+uv run --no-sync python -m pytest tests/ --cov=guildbotics --cov-report=xml
+
+# desktop frontend（desktop/ を触る場合）
+cd desktop && npm ci && npm run quality
+# desktop E2E（実ブラウザ + 実 Local API backend。`npm run quality` / push CI には含めない）:
+#   npm run e2e:install   # 初回のみ
+#   npm run e2e
+```
+
+`uv sync` で `pyproject.toml` に固定された依存をインストールします。
 
 ## Coding Style & Naming Conventions
-- Python 3.11+；4スペースインデント；完全な型ヒントを優先。
-- Blackでフォーマット (88列)。例: `python -m black .`
-- インポート: stdlib、サードパーティ、ローカル (グループ化およびソート)。
+- Python 3.12+（`requires-python = ">=3.12,<3.14"`）；4スペースインデント；完全な型ヒントを優先。
+- フォーマット/Lint は Ruff が正典。CI は `ruff format --check` と `ruff check` を実行。ローカル整形は `uv run --no-sync ruff format guildbotics`。
+- インポート: stdlib、サードパーティ、ローカル (グループ化およびソート；Ruff が処理)。
 - 命名: モジュール/関数/変数 `snake_case`、クラス `PascalCase`、定数 `UPPER_SNAKE_CASE`。
 - ログを構造化して保持: `%(asctime)s [%(levelname)s] [%(threadName)s] %(message)s`。
 - ソースコード内のコメントを英語で記述。Googleスタイルのdocstringを使用。
@@ -29,14 +43,16 @@
 - シンプルさ優先: KISSを適用；投機的な抽象化を避ける (YAGNI)。
 - 実用的SOLID: 特にSingle Responsibility—肥大化した関数/モジュールを避ける。
 - DRY: コピー&ペーストの重複なし；共有ロジックを `utils/` または適切な共有モジュールにファクタリング。
-- 一方向依存: 循環インポート/アーキテクチャサイクルを防ぐ；低レベルモジュール (`entities/`、`utils/`) は高レベルオーケストレーションレイヤー (`workflows/`、`drivers/`) に依存しない。
+- 一方向依存: 循環インポート/アーキテクチャサイクルを防ぐ；低レベルモジュール (`entities/`、`utils/`) は高レベルオーケストレーションレイヤー (`templates/`、`commands/`、`drivers/`) に依存しない。
 - 既存アーキテクチャを尊重: 境界を変更する前に `docs/ARCHITECTURE.*.md` をレビュー。
 - パフォーマンスマインドセット: 時期尚早の最適化を避けるが、発見された明らかな非効率性 (N+1呼び出し、無駄なI/O、過度の複雑さ) を修正。
 
 ## Testing Guidelines
-- フレームワーク: pytest。テストを `tests/` の下に `test_*.py` という名前で配置。
-- ユニットテストのパッケージ構造をミラーリング；ワークフロー/統合シナリオには `tests/it/` を使用。
-- `monkeypatch` を時間、ランダム性、I/Oに使用；テストを決定論的に保つ。
+テスト戦略の全体（どの層をカバーするか、テストピラミッド、desktop の lean-but-real な E2E 方針）は `AGENTS.md`「テスト実装の考え方」が正典です。プロセス上の要点:
+
+- フレームワーク: pytest。`tests/guildbotics/` 配下にパッケージ構成をミラーして `test_*.py` で配置。統合テスト（FastAPI `TestClient`・temp workspace）も同じ配下（例: `tests/guildbotics/app_api/`）。`tests/it/` という別ツリーは存在しない。
+- desktop frontend: unit/component は Vitest + React Testing Library、加えて `desktop/e2e/` の実ブラウザ Playwright journey を少数（`desktop/README.md` 参照）。
+- `monkeypatch` / `tmp_path` を時間・ランダム性・env・cwd・HOME・I/O に使用し、決定論的かつ hermetic に保つ（実 home や外部サービスに触れない）。
 - カバレッジを維持または改善；ローカルで `coverage.xml` の更新を確認。
 - 結果を正直に報告；失敗が発生したときに成功を述べない。
 - 環境制限を早期に開示 (不足している資格情報、無効化されたサービス) し、重要なロジックを黙ってスキップしない。
@@ -45,7 +61,7 @@
 ## Commit & Pull Request Guidelines
 - Conventional Commitsを使用: `feat:`、`fix:`、`chore:`、`refactor:` など。短い、命令形の件名；詳細は本文に。英語または日本語で可。
 - PR: 明確な説明、リンクされたイシュー (`#123`)、関連するスクリーンショット/ログ、再現とテストステップ、環境/設定変更の注記。
-- レビューをリクエストする前に `uv run --no-sync ruff check guildbotics`、`uv run --no-sync mypy guildbotics`、`pytest` が合格することを確認。
+- レビューをリクエストする前に、CI 相当のチェック（「PR を出す前に」参照）が合格することを確認: Python は `ruff format --check`・`ruff check`・`mypy`・`pylint`・`pytest`、frontend を触る場合は `desktop/` で `npm run quality`（cross-boundary な journey を変える場合は `npm run e2e` も）。
 
 ## Code Review Etiquette
 - すべてのフィードバックに対処 (実装または明確化)；コメントを無視しない。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,25 +1,39 @@
 # Contributing Guidelines
 
-## Project Structure & Module Organization
-- `guildbotics/`: Core package. Key modules include `drivers/` (schedulers), `workflows/` (task orchestration), `intelligences/` (brains), `integrations/`, `loader/`, `runtime/`, `entities/`, `utils/`, and `templates/`.
-- `tests/`: Pytest suite. Unit tests mirror package paths under `tests/guildbotics/`; integration tests live in `tests/it/` with sample configs in `tests/it/config/`.
-- `docs/`: Architecture and design (`docs/ARCHITECTURE.*.md`).
-- `main.py`: Entry point for running the scheduler.
-- `.env`, `.env.example`: Local configuration.
+This document covers the **human contribution process**. For repository structure, environment setup, the CI-equivalent build/test/lint commands, coding standards, and the testing strategy, treat the following as the **single source of truth** — they are kept current with CI, so this file does not duplicate (and drift from) them:
 
-## Build, Test, and Development Commands
-- Sync dependencies for CI-equivalent checks: `uv sync --extra test --extra dev`
-- Run lint checks: `uv run --no-sync ruff check guildbotics`
-- Run type checks: `uv run --no-sync mypy guildbotics`
-- Run tests and create coverage report: `uv run --no-sync python -m pytest tests/ --cov=guildbotics --cov-report=xml` (output: `coverage.xml`).
-- Recommended local verification order: `ruff` -> `mypy` -> `pytest`
+- **`AGENTS.md`** — repository working guide: module layout, config resolution, CLI, the CI-equivalent commands, and the testing strategy.
+- **`desktop/README.md`** — desktop app build, development, and tests (Vitest unit/component + Playwright E2E).
+- **`.github/workflows/ci.yml`** — the exact checks CI enforces.
 
-Note: This repository provides a fixed dependency file `pyproject.toml`. Use `uv sync` to install the required libraries.
+Tests live under `tests/guildbotics/` mirroring the package layout (there is no separate `tests/it/` tree); the CLI entry point is `guildbotics` (`guildbotics.cli:main`), not a `main.py`.
+
+## Before opening a PR — run the CI-equivalent checks
+
+The authoritative list lives in `AGENTS.md` ("開発時の基本コマンド (CI 準拠)"). Quick reference:
+
+```bash
+# Python (repo root)
+uv sync --extra test --extra dev
+uv run --no-sync ruff format --check guildbotics
+uv run --no-sync ruff check guildbotics
+uv run --no-sync mypy guildbotics
+uv run --no-sync pylint guildbotics
+uv run --no-sync python -m pytest tests/ --cov=guildbotics --cov-report=xml
+
+# Desktop frontend (desktop/) — when touching desktop/
+cd desktop && npm ci && npm run quality
+# Desktop E2E (real browser + Local API backend; NOT in `npm run quality` or push CI):
+#   npm run e2e:install   # first run only
+#   npm run e2e
+```
+
+`uv sync` installs the pinned dependencies from `pyproject.toml`.
 
 ## Coding Style & Naming Conventions
-- Python 3.11+; 4-space indent; prefer full type hints.
-- Format with Black (88 cols). Example: `python -m black .`
-- Imports: stdlib, third-party, local (grouped and sorted).
+- Python 3.12+ (`requires-python = ">=3.12,<3.14"`); 4-space indent; prefer full type hints.
+- Format and lint with Ruff — the source of truth. CI runs `ruff format --check` and `ruff check`; apply locally with `uv run --no-sync ruff format guildbotics`.
+- Imports: stdlib, third-party, local (grouped and sorted; handled by Ruff).
 - Naming: modules/funcs/vars `snake_case`, classes `PascalCase`, constants `UPPER_SNAKE_CASE`.
 - Keep logs structured: `%(asctime)s [%(levelname)s] [%(threadName)s] %(message)s`.
 - Write comments in the source code in English. Use Google-style docstrings.
@@ -34,18 +48,21 @@ Note: This repository provides a fixed dependency file `pyproject.toml`. Use `uv
 - Performance mindset: do not prematurely optimize, but fix evident inefficiencies (N+1 calls, needless I/O, excessive complexity) when discovered.
 
 ## Testing Guidelines
-- Framework: pytest. Place tests under `tests/` with files named `test_*.py`.
-- Mirror package structure for unit tests; use `tests/it/` for workflow/integration scenarios.
-- Use `monkeypatch` for time, randomness, and I/O; keep tests deterministic.
+The full testing strategy (which layer to cover, the test pyramid, and the lean-but-real desktop E2E policy) is canonical in `AGENTS.md` → "テスト実装の考え方". Process essentials:
+
+- Framework: pytest. Place tests under `tests/guildbotics/` mirroring the package layout, with files named `test_*.py`. Integration tests (FastAPI `TestClient`, temp-workspace) live alongside, e.g. `tests/guildbotics/app_api/`. There is no separate `tests/it/` tree.
+- Desktop frontend: Vitest + React Testing Library for unit/component, and a small set of real-browser Playwright journeys under `desktop/e2e/` (see `desktop/README.md`).
+- Use `monkeypatch`/`tmp_path` for time, randomness, env, cwd, HOME, and I/O; keep tests deterministic and hermetic (never touch the real home dir or external services).
 - Maintain or improve coverage; verify `coverage.xml` updates locally.
 - Report results honestly; never state success when failures occurred.
 - Disclose environment limitations early (missing creds, disabled services) instead of silently skipping critical logic.
 - Design for testability: small pure functions, clear side-effect boundaries, explicit dependency injection where helpful.
+- Desktop frontend follows the same pyramid: Vitest + React Testing Library for unit/component tests (assert role/text/value/payload, not implementation detail), plus a small set of lean-but-real Playwright journeys under `desktop/e2e/` for cross-boundary critical paths exercised against a real browser and a real Local API backend. Keep exhaustive branch coverage in unit/component; reserve E2E for what only a real browser + real wire can verify. See `docs/test_gap_analysis.ja.md` for the canonical strategy.
 
 ## Commit & Pull Request Guidelines
 - Use Conventional Commits: `feat:`, `fix:`, `chore:`, `refactor:`, etc. Short, imperative subject; details in body. English or Japanese is fine.
 - PRs: clear description, linked issues (`#123`), screenshots/logs when relevant, reproduction and test steps, and note any env/config changes.
-- Ensure `uv run --no-sync ruff check guildbotics`, `uv run --no-sync mypy guildbotics`, and `pytest` pass before requesting review.
+- Ensure the CI-equivalent checks (see "Before opening a PR") pass before requesting review: `ruff format --check`, `ruff check`, `mypy`, `pylint`, and `pytest` for Python; `npm run quality` under `desktop/` when touching the frontend (plus `npm run e2e` when changing a cross-boundary journey).
 
 ## Code Review Etiquette
 - Address all feedback (implement or clarify); do not ignore comments.

--- a/desktop/.gitignore
+++ b/desktop/.gitignore
@@ -2,3 +2,12 @@ dist/
 node_modules/
 src-tauri/target/
 src-tauri/binaries/
+
+# Playwright E2E artifacts
+/test-results/
+/playwright-report/
+/e2e/.stack-context.json
+/e2e/.stack-context-configured.json
+/e2e/.stack-context-members.json
+/e2e/.stack-context-diagnostics.json
+/e2e/.stack-context-down.json

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -8,6 +8,110 @@ GuildBotics の macOS 向けデスクトップ GUI です。Tauri v2 + TypeScrip
 
 ---
 
+## クイック操作スクリプト
+
+リポジトリルートから以下を実行できます。通常の再テストではこちらを使うと、§2 / §3 の手順を直接打たずに済みます。
+
+### ビルド
+
+```bash
+# Python sidecar のみ
+scripts/desktop-build-backend.sh
+
+# Tauri / DMG のみ（事前に sidecar が必要）
+scripts/desktop-build-frontend.sh
+
+# sidecar と Tauri / DMG をまとめて build
+scripts/desktop-build-all.sh
+```
+
+`desktop-build-frontend.sh` は `desktop/src-tauri/binaries/guildbotics-app-api-aarch64-apple-darwin` を使って DMG を作ります。別ターゲットを使う場合は `DESKTOP_TARGET` を指定してください。
+
+```bash
+DESKTOP_TARGET=aarch64-apple-darwin scripts/desktop-build-all.sh
+```
+
+### 開発モード起動
+
+```bash
+# Local API backend のみ（既定: http://127.0.0.1:8765 / token: dev-token）
+scripts/desktop-dev-backend.sh
+
+# Vite frontend のみ（backend は別途起動しておく）
+scripts/desktop-dev-frontend.sh
+
+# backend と frontend をまとめて起動
+scripts/desktop-dev-all.sh
+```
+
+backend の接続先は必要に応じて変更できます。
+
+```bash
+GUILDBOTICS_APP_API_PORT=8877 \
+GUILDBOTICS_APP_API_TOKEN=local-token \
+scripts/desktop-dev-all.sh
+```
+
+---
+
+## テスト
+
+### frontend unit / component（Vitest + React Testing Library）
+
+```bash
+cd desktop
+npm ci
+npm run test          # 一括実行
+npm run test:watch    # ウォッチ
+npm run quality       # format:check + lint + typecheck + duplicates + test（E2E は含まない）
+```
+
+### E2E（Playwright・実ブラウザ + 実 Local API backend）
+
+jsdom では検証できない「実ブラウザ engine + 実 `client.ts ↔ FastAPI ↔ EventBus(websocket)` + 実ファイル書き込み」を貫く critical user journey を検証します。Tauri は使わず browser-preview mode で実 backend に接続し、各 journey を専用の temp workspace と backend / frontend ポートで隔離して起動します。
+
+前提:
+
+- リポジトリルートで Python 依存を解決済みであること（harness が `uv run python -m guildbotics.app_api` を起動するため）。
+
+  ```bash
+  uv sync --extra test --extra dev
+  ```
+
+- 初回のみ chromium を取得する。
+
+  ```bash
+  cd desktop
+  npm run e2e:install
+  ```
+
+実行:
+
+```bash
+cd desktop
+npm run e2e
+```
+
+`npm run e2e` は backend（temp workspace）と Vite を自動起動 → headless chromium で以下の journey を実行 → プロセスを停止します（ライフサイクルは `desktop/e2e/start-stack.mjs`、構成は `desktop/playwright.config.ts`）。
+
+| spec | journey |
+|---|---|
+| `e2e/setup.spec.ts` | ① 初回 setup → 作成 → backend が `project.yml` を実書き込み |
+| `e2e/service.spec.ts` | ③ scheduler / events を start → running → stop |
+| `e2e/commands.spec.ts` | ④ command 実行 → `/commands/run` + `/events` ストリーム → history 反映 |
+| `e2e/members.spec.ts` | ② member 追加 → `person.yml` 実永続 |
+| `e2e/diagnostics.spec.ts` | ⑤ verify / scenario diagnostics 実行 → 結果描画 |
+| `e2e/failure.spec.ts` | ⑥ backend down → Bootstrap error → 復帰 → retry |
+
+補足:
+
+- レポート / 成果物は `desktop/playwright-report/` と `desktop/test-results/`（いずれも `.gitignore` 済み）。
+- E2E は `npm run quality` と通常 push CI には含めず、専用ジョブ（workflow_dispatch / nightly）で回す方針（`docs/test_gap_analysis.ja.md` 参照）。
+- 接続先 host / ポートは `GUILDBOTICS_E2E_*` 環境変数で上書き可能（既定値は `playwright.config.ts`）。
+- Tauri ネイティブ（packaged app / sidecar 起動 / file picker）の smoke は別ティアで、実 macOS + Tauri runtime が必要（§2〜§3 のビルド手順を参照）。
+
+---
+
 ## 1. 前提ツール
 
 | ツール | バージョン目安 | 用途 |

--- a/desktop/e2e/commands.spec.ts
+++ b/desktop/e2e/commands.spec.ts
@@ -1,0 +1,73 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { expect, test } from "@playwright/test";
+
+// Journey ④: Commands against the REAL backend.
+//
+// The "configured" harness pre-seeds the temp workspace, which also installs the
+// sample commands (translate / summarize / get-time-of-day / context-info). This
+// journey selects the `context-info` sample command — a deterministic, no-LLM,
+// no-GitHub command (`brain: none`, jinja2 template) — runs it through the REAL
+// `/commands/run` endpoint, and asserts that the run output and the
+// command.started / command.finished `/events` websocket frames surface in the
+// run history.
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+type StackContext = {
+  memberId: string | null;
+  configDir: string;
+};
+
+function readConfiguredContext(): StackContext {
+  const raw = readFileSync(join(here, ".stack-context-configured.json"), "utf-8");
+  return JSON.parse(raw) as StackContext;
+}
+
+test("runs the seeded context-info command and shows real output + events", async ({ page }) => {
+  const ctx = readConfiguredContext();
+
+  await page.goto("/#/commands");
+  await expect(page.getByRole("heading", { name: "Run Command" })).toBeVisible();
+
+  // The seeded active member is preselected; no blocked alert should be shown.
+  await expect(page.getByText("No active members")).toHaveCount(0);
+
+  // Select the deterministic sample command from the searchable catalog. The
+  // option's accessible name also carries the description (custom renderOption),
+  // so match the label substring rather than an exact string.
+  const commandSelect = page.getByRole("textbox", { name: "Command", exact: true });
+  await commandSelect.click();
+  await commandSelect.fill("context-info");
+  await page.getByRole("option", { name: /Context Info \(context-info\)/ }).click();
+  // The selected command surfaces its on-disk script path; assert on that rather
+  // than the search input's internal value (Mantine keeps the typed query there).
+  await expect(page.getByRole("link", { name: /context-info\.md$/ })).toBeVisible({
+    timeout: 30_000,
+  });
+
+  // Run it against the REAL backend.
+  const run = page.getByRole("button", { name: "Run", exact: true });
+  await expect(run).toBeEnabled();
+  await run.click();
+
+  // The run history surfaces the request and reaches a terminal success state,
+  // driven by the real command.started / command.finished websocket frames and
+  // the /commands/run response.
+  await expect(page.getByText(/^Request /)).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByText("Success")).toBeVisible({ timeout: 30_000 });
+
+  // The Output tab shows the deterministic template output rendered by the
+  // backend for the seeded member + team (jinja2, no LLM).
+  const output = page.locator("pre.command-output").first();
+  await expect(output).toContainText("Language code: en", { timeout: 30_000 });
+  await expect(output).toContainText(`ID: ${ctx.memberId}`);
+  await expect(output).toContainText("Name: Local Agent");
+
+  // The Events tab lists the real command.* websocket frames for this request.
+  await page.getByRole("tab", { name: "Events" }).click();
+  await expect(page.getByText("started")).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByText("finished")).toBeVisible({ timeout: 30_000 });
+});

--- a/desktop/e2e/diagnostics.spec.ts
+++ b/desktop/e2e/diagnostics.spec.ts
@@ -1,0 +1,62 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { expect, test } from "@playwright/test";
+
+// Journey ⑤: Diagnostics against the REAL backend.
+//
+// The "diagnostics" stack is seeded like the configured one: a project with a
+// fake OpenAI key (`sk-e2e-test-key`) and CLI agent `codex`, GitHub/Slack
+// disabled. This journey:
+//   * asserts the readiness tab renders backend-derived status badges (config
+//     Ready, env Found, GitHub Disabled) for the seeded workspace;
+//   * runs the real scenario diagnostics (`POST /diagnostics/scenario`) and
+//     asserts the LLM check FAILS — the fake key cannot satisfy a live LLM call,
+//     so the backend deterministically returns an error check that surfaces as a
+//     red "LLM check failed" alert.
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+type StackContext = {
+  seeded: boolean;
+  memberId: string | null;
+};
+
+function readDiagnosticsContext(): StackContext {
+  const raw = readFileSync(join(here, ".stack-context-diagnostics.json"), "utf-8");
+  return JSON.parse(raw) as StackContext;
+}
+
+test("renders readiness badges and reports the real LLM failure from scenario diagnostics", async ({
+  page,
+}) => {
+  const ctx = readDiagnosticsContext();
+  expect(ctx.seeded).toBe(true);
+
+  await page.goto("/#/diagnostics");
+  await expect(page.getByRole("heading", { name: "Diagnostics" })).toBeVisible();
+
+  // Readiness badges are derived from the real /config/status, /team and
+  // /config/project responses for the seeded workspace: config "Configured",
+  // env file "Detected", GitHub "Disabled".
+  await expect(page.getByText("Configured", { exact: true })).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByText("Detected", { exact: true })).toBeVisible();
+  await expect(page.getByText("Disabled", { exact: true })).toBeVisible();
+
+  // Run the real read-only scenario diagnostics.
+  const runButton = page.getByRole("button", { name: "Validate settings" });
+  await expect(runButton).toBeEnabled();
+  await runButton.click();
+
+  // The seeded fake OpenAI key cannot complete a live LLM call, so the backend
+  // returns an error check that the UI renders as a red "LLM check failed" alert.
+  // Use a generous timeout: the real provider call must round-trip and fail.
+  await expect(page.getByText("LLM check failed")).toBeVisible({ timeout: 45_000 });
+  await expect(
+    page.getByText("The selected LLM provider did not accept the minimal validation request."),
+  ).toBeVisible();
+
+  // The all-ok summary must NOT appear when a check failed.
+  await expect(page.getByText("Settings validated")).toHaveCount(0);
+});

--- a/desktop/e2e/diagnostics.spec.ts
+++ b/desktop/e2e/diagnostics.spec.ts
@@ -6,20 +6,23 @@ import { expect, test } from "@playwright/test";
 
 // Journey ⑤: Diagnostics against the REAL backend.
 //
-// The "diagnostics" stack is seeded like the configured one: a project with a
-// fake OpenAI key (`sk-e2e-test-key`) and CLI agent `codex`, GitHub/Slack
-// disabled. This journey:
+// The "diagnostics" stack is seeded WITHOUT an LLM API key (offline mode), so
+// the backend's missing-key short-circuit in `_check_llm` returns a fast error
+// WITHOUT firing a live LLM call. This keeps `npm run e2e` fully offline and
+// deterministic — no dependency on api.openai.com latency or availability —
+// while still exercising the real backend-frontend wiring end-to-end. This
+// journey:
 //   * asserts the readiness tab renders backend-derived status badges (config
-//     Ready, env Found, GitHub Disabled) for the seeded workspace;
+//     Configured, env Detected, GitHub Disabled) for the seeded workspace;
 //   * runs the real scenario diagnostics (`POST /diagnostics/scenario`) and
-//     asserts the LLM check FAILS — the fake key cannot satisfy a live LLM call,
-//     so the backend deterministically returns an error check that surfaces as a
-//     red "LLM check failed" alert.
+//     asserts the missing-key check renders the i18n-mapped "LLM API key is
+//     missing" alert, plus a context line naming the env var (OPENAI_API_KEY).
 
 const here = dirname(fileURLToPath(import.meta.url));
 
 type StackContext = {
   seeded: boolean;
+  seededWithoutLlmKey: boolean;
   memberId: string | null;
 };
 
@@ -28,11 +31,12 @@ function readDiagnosticsContext(): StackContext {
   return JSON.parse(raw) as StackContext;
 }
 
-test("renders readiness badges and reports the real LLM failure from scenario diagnostics", async ({
+test("renders readiness badges and reports the missing-key LLM check from scenario diagnostics", async ({
   page,
 }) => {
   const ctx = readDiagnosticsContext();
   expect(ctx.seeded).toBe(true);
+  expect(ctx.seededWithoutLlmKey).toBe(true);
 
   await page.goto("/#/diagnostics");
   await expect(page.getByRole("heading", { name: "Diagnostics" })).toBeVisible();
@@ -44,18 +48,19 @@ test("renders readiness badges and reports the real LLM failure from scenario di
   await expect(page.getByText("Detected", { exact: true })).toBeVisible();
   await expect(page.getByText("Disabled", { exact: true })).toBeVisible();
 
-  // Run the real read-only scenario diagnostics.
+  // Run the real read-only scenario diagnostics. With no OpenAI key configured
+  // the backend short-circuits BEFORE any network call, so this resolves in
+  // milliseconds rather than waiting for a live HTTPS round-trip.
   const runButton = page.getByRole("button", { name: "Validate settings" });
   await expect(runButton).toBeEnabled();
   await runButton.click();
 
-  // The seeded fake OpenAI key cannot complete a live LLM call, so the backend
-  // returns an error check that the UI renders as a red "LLM check failed" alert.
-  // Use a generous timeout: the real provider call must round-trip and fail.
-  await expect(page.getByText("LLM check failed")).toBeVisible({ timeout: 45_000 });
-  await expect(
-    page.getByText("The selected LLM provider did not accept the minimal validation request."),
-  ).toBeVisible();
+  // The missing-key check uses the existing `llm_api_key` i18n entry shared
+  // with the static verify checks: title "LLM API key is missing" + the
+  // env-var detail "OPENAI_API_KEY is not configured" surfaced from the
+  // backend's check message.
+  await expect(page.getByText("LLM API key is missing")).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByText(/OPENAI_API_KEY is not configured/)).toBeVisible();
 
   // The all-ok summary must NOT appear when a check failed.
   await expect(page.getByText("Settings validated")).toHaveCount(0);

--- a/desktop/e2e/failure.spec.ts
+++ b/desktop/e2e/failure.spec.ts
@@ -1,0 +1,68 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { expect, test } from "@playwright/test";
+
+// Journey ⑥: critical failure — backend DOWN at app load, then recover.
+//
+// The "down" stack boots the frontend pointed at a backend port that is NOT yet
+// serving (see start-stack.mjs `GUILDBOTICS_E2E_DEFER_BACKEND`). On load the app's
+// Bootstrap calls startBackend() → waitForHealth() against the dead port, which
+// fails its real deadline and renders the error alert + a Retry button.
+//
+// Recovery is made DETERMINISTIC (not timing-flaky) by a control server: the spec
+// POSTs `/control/start-backend`, which starts the REAL backend and only answers
+// 200 AFTER `/health` is green. The subsequent Retry click therefore always finds
+// a healthy backend, so the app loads. The 45s real health deadline in the app's
+// waitForHealth is why this journey needs an extended timeout.
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+type StackContext = {
+  controlPort: number;
+  host: string;
+  deferBackend: boolean;
+};
+
+function readDownContext(): StackContext {
+  const raw = readFileSync(join(here, ".stack-context-down.json"), "utf-8");
+  return JSON.parse(raw) as StackContext;
+}
+
+test("shows the backend-down error, then recovers on retry once the backend is up", async ({
+  page,
+}) => {
+  // The initial backend-down detection rides the app's real ~45s health deadline,
+  // then the retry must wait for the backend to become healthy, so budget well
+  // beyond the default 60s.
+  test.setTimeout(150_000);
+
+  const ctx = readDownContext();
+  expect(ctx.deferBackend).toBe(true);
+
+  await page.goto("/");
+
+  // Backend is down: Bootstrap surfaces the failure alert and a Retry button.
+  // This appears only after the app's real waitForHealth deadline elapses.
+  await expect(page.getByText("GuildBotics could not start")).toBeVisible({ timeout: 60_000 });
+  const retry = page.getByRole("button", { name: "Retry" });
+  await expect(retry).toBeVisible();
+  // The app is NOT mounted while the backend is unreachable.
+  await expect(page.getByRole("navigation")).toHaveCount(0);
+
+  // Bring the REAL backend up on demand via the control server. The control
+  // endpoint only returns once `/health` is green, so the retry below cannot race
+  // ahead of a ready backend.
+  const controlUrl = `http://${ctx.host}:${ctx.controlPort}/control/start-backend`;
+  const response = await page.request.post(controlUrl);
+  expect(response.ok()).toBe(true);
+  expect((await response.json()).status).toBe("ready");
+
+  // Retry now succeeds: Bootstrap resolves and the App mounts (sidebar nav +
+  // landing service screen for the empty workspace's first-setup, whichever the
+  // router lands on — the nav is the reliable "app mounted" signal).
+  await retry.click();
+  await expect(page.getByText("GuildBotics could not start")).toHaveCount(0, { timeout: 60_000 });
+  await expect(page.getByRole("navigation")).toBeVisible({ timeout: 60_000 });
+});

--- a/desktop/e2e/members.spec.ts
+++ b/desktop/e2e/members.spec.ts
@@ -1,0 +1,59 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { expect, test } from "@playwright/test";
+
+// Journey ②: add a team member through the UI against the REAL backend.
+//
+// This stack ("members") is seeded exactly like the configured stack — one
+// active member, `Local Agent (local-agent)` — but kept isolated so mutating the
+// member list never perturbs the service / commands journeys. The test opens the
+// Members section of the configured Settings screen, adds a SECOND active member
+// through the real `POST /config/members` wire, then asserts BOTH members render
+// in the reloaded list and that the backend persisted the new member on disk.
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+type StackContext = {
+  configDir: string;
+  memberId: string | null;
+  seeded: boolean;
+};
+
+function readMembersContext(): StackContext {
+  const raw = readFileSync(join(here, ".stack-context-members.json"), "utf-8");
+  return JSON.parse(raw) as StackContext;
+}
+
+test("adds a second member through the UI and persists it to the backend", async ({ page }) => {
+  const ctx = readMembersContext();
+  expect(ctx.seeded).toBe(true);
+
+  // The Members section of the configured Settings screen (deep link, mirroring
+  // SetupPage.test.tsx `?section=members`).
+  await page.goto("/#/setup?section=members");
+  await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
+
+  // The seeded member is already listed.
+  await expect(page.getByText("Local Agent (local-agent)")).toBeVisible({ timeout: 30_000 });
+
+  // With a member already configured the add form is collapsed behind the
+  // "Add new member" toggle; reveal it, then fill the required Basic fields. The
+  // add form is pre-populated with the "professional" preset, so only the id and
+  // display name are missing for a human member.
+  await page.getByRole("button", { name: "Add new member" }).click();
+  await page.getByLabel("Member ID").fill("local-agent-2");
+  await page.getByLabel("Display name").fill("Second Agent");
+  await page.getByRole("button", { name: "Add member" }).click();
+
+  // The reloaded list (driven by the real /team response) now shows BOTH members.
+  await expect(page.getByText("Second Agent (local-agent-2)")).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByText("Local Agent (local-agent)")).toBeVisible();
+
+  // The REAL backend wrote the new member's person.yml under the temp workspace.
+  const personFile = join(ctx.configDir, "team", "members", "local-agent-2", "person.yml");
+  expect(existsSync(personFile)).toBe(true);
+  const personYaml = readFileSync(personFile, "utf-8");
+  expect(personYaml).toContain("Second Agent");
+});

--- a/desktop/e2e/service.spec.ts
+++ b/desktop/e2e/service.spec.ts
@@ -1,0 +1,121 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { expect, test, type Locator, type Page } from "@playwright/test";
+
+// Journey ③: Service Runtime against the REAL backend.
+//
+// The "configured" harness (`e2e/start-stack.mjs` with GUILDBOTICS_E2E_SEED=1)
+// pre-seeds the temp workspace with a project + one active member (GitHub
+// integration disabled), so the app boots already-configured.
+//
+// In this seeded workspace the only scheduler routine is
+// `workflows/ticket_driven_workflow`, which the REAL backend reports as
+// requiring GitHub. So the scheduler target is GitHub-blocked, while the events
+// (chat handling) target has no such requirement. This journey therefore:
+//   * starts the events target, observes the UI reach a running state driven by
+//     the REAL backend status/websocket events, then stops and observes stopped;
+//   * asserts the scheduler-only selection is blocked by the backend-derived
+//     GitHub requirement (real start guard), which also proves the per-target
+//     toggle changes what the app is allowed to send.
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+const RUN_BUTTON = "Run";
+const STOP_BUTTON = "Stop";
+
+type StackContext = {
+  workspaceDir: string;
+  memberId: string | null;
+  seeded: boolean;
+};
+
+function readConfiguredContext(): StackContext {
+  const raw = readFileSync(join(here, ".stack-context-configured.json"), "utf-8");
+  return JSON.parse(raw) as StackContext;
+}
+
+function panel(page: Page, title: string): Locator {
+  return page.locator(".service-unit-panel").filter({ hasText: title }).first();
+}
+
+// Mantine renders the switch as a visually-hidden <input> with a visible track
+// rendered from the input's <label>, so the input itself is not click-actionable
+// in a real browser. Clicking the visible track toggles it the way a user would.
+async function toggleTarget(panelLocator: Locator): Promise<void> {
+  await panelLocator.locator(".service-unit-switch .mantine-Switch-track").click();
+}
+
+async function ensureStopped(page: Page): Promise<void> {
+  const stop = page.getByRole("button", { name: STOP_BUTTON });
+  if (await stop.isVisible().catch(() => false)) {
+    await stop.click();
+    await expect(page.getByRole("button", { name: RUN_BUTTON })).toBeVisible({ timeout: 30_000 });
+  }
+}
+
+test.beforeEach(async ({ page }) => {
+  // Each test starts from a stopped runtime, regardless of order. The service
+  // screen only renders the Stop button while running, so this no-ops when the
+  // runtime is already stopped.
+  await page.goto("/#/service");
+  await expect(page.getByRole("heading", { name: "Service Runtime" })).toBeVisible();
+  await ensureStopped(page);
+});
+
+test("seeded workspace boots configured and lands on the service screen", () => {
+  const ctx = readConfiguredContext();
+  expect(ctx.seeded).toBe(true);
+  expect(ctx.memberId).toBe("local-agent");
+});
+
+test("starts the events target, reaches running via real events, then stops", async ({ page }) => {
+  await page.goto("/#/service");
+  await expect(page.getByRole("heading", { name: "Service Runtime" })).toBeVisible();
+
+  const schedulerPanel = panel(page, "Auto patrol");
+  const eventsPanel = panel(page, "Chat handling");
+
+  // Disable the GitHub-requiring scheduler target so the events target alone is
+  // started; with it enabled the backend-derived GitHub guard blocks Start.
+  await toggleTarget(schedulerPanel);
+
+  const start = page.getByRole("button", { name: RUN_BUTTON });
+  await expect(start).toBeEnabled();
+  await start.click();
+
+  // The REAL backend reports the events unit running; the UI swaps Start for Stop
+  // and the events panel state badge reads "Running". The state badge lives in the
+  // panel title row (the "Stopped" field label below would otherwise collide).
+  const stop = page.getByRole("button", { name: STOP_BUTTON });
+  await expect(stop).toBeVisible({ timeout: 30_000 });
+  await expect(eventsPanel.locator(".service-unit-title").getByText("Running")).toBeVisible({
+    timeout: 30_000,
+  });
+  // The disabled scheduler target never reaches a running state.
+  await expect(schedulerPanel.locator(".service-unit-title").getByText("Running")).toHaveCount(0);
+
+  // Stop and observe the runtime return to a stopped state driven by the backend.
+  await stop.click();
+  await expect(start).toBeVisible({ timeout: 30_000 });
+  await expect(eventsPanel.locator(".service-unit-title").getByText("Stopped")).toBeVisible({
+    timeout: 30_000,
+  });
+});
+
+test("scheduler-only is blocked by the backend GitHub requirement", async ({ page }) => {
+  await page.goto("/#/service");
+  await expect(page.getByRole("heading", { name: "Service Runtime" })).toBeVisible();
+
+  // Leave only the scheduler target enabled.
+  await toggleTarget(panel(page, "Chat handling"));
+
+  // The default routine requires GitHub, which is disabled in the seeded
+  // workspace, so the REAL backend-derived guard disables Start and surfaces the
+  // GitHub guard alert.
+  await expect(page.getByText("This routine requires GitHub integration")).toBeVisible({
+    timeout: 30_000,
+  });
+  await expect(page.getByRole("button", { name: RUN_BUTTON })).toBeDisabled();
+});

--- a/desktop/e2e/setup.spec.ts
+++ b/desktop/e2e/setup.spec.ts
@@ -1,0 +1,89 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { expect, test } from "@playwright/test";
+
+// Journey ①: first-run setup happy path against the REAL backend.
+//
+// The harness (`e2e/start-stack.mjs`) boots the Python Local API in a fresh temp
+// workspace, so the app lands on first-setup. This test fills the required form
+// fields exactly as `SetupPage.test.tsx` does, clicks Create, asserts the app
+// transitions to the service screen, and then reads the project.yml the backend
+// wrote on disk to confirm the wire actually persisted the config.
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+type StackContext = {
+  workspaceDir: string;
+  homeDir: string;
+  backendPort: number;
+  frontendPort: number;
+  token: string;
+  host: string;
+};
+
+function readStackContext(): StackContext {
+  const raw = readFileSync(join(here, ".stack-context.json"), "utf-8");
+  return JSON.parse(raw) as StackContext;
+}
+
+test("first-run setup happy path writes project.yml and enters the service view", async ({
+  page,
+}) => {
+  const ctx = readStackContext();
+
+  await page.goto("/");
+
+  // The empty temp workspace has no config, so the landing redirect lands on the
+  // first-setup screen.
+  await expect(page.getByRole("heading", { name: "First setup" })).toBeVisible();
+
+  // The working directory is pre-filled from the backend cwd (the temp
+  // workspace). Allow for macOS /private symlink normalization.
+  const workspaceField = page.getByLabel("Working directory");
+  await expect
+    .poll(async () => (await workspaceField.inputValue()).replace(/^\/private/, ""))
+    .toBe(ctx.workspaceDir.replace(/^\/private/, ""));
+
+  // Project section: description.
+  await page.getByLabel("Project description").fill("E2E automation workspace");
+
+  // LLM / CLI agent section: provide an API key for the default OpenAI provider.
+  // The section nav buttons share text with option cards (e.g. "GitHub" vs
+  // "GitHub Copilot CLI"), so match the nav buttons exactly.
+  await page.getByRole("button", { name: "LLM / CLI agent", exact: true }).click();
+  await page.getByLabel("OpenAI API key").fill("sk-e2e-test-key");
+
+  // GitHub section: choose the disabled decision.
+  await page.getByRole("button", { name: "GitHub", exact: true }).click();
+  await page.getByRole("textbox", { name: "GitHub integration" }).click();
+  await page.getByRole("option", { name: "Do not use GitHub" }).click();
+
+  // Members section: add one active member so the section is complete. The add
+  // form is shown by default and pre-filled with character defaults.
+  await page.getByRole("button", { name: "Members", exact: true }).click();
+  await page.getByLabel("Member ID").fill("local-agent");
+  await page.getByLabel("Display name").fill("Local Agent");
+  await page.getByRole("button", { name: "Add member" }).click();
+
+  // Create the initial settings.
+  const createButton = page.getByRole("button", { name: "Create initial settings" });
+  await expect(createButton).toBeEnabled();
+  await createButton.click();
+
+  // The app reports success and switches into settings (configured) mode.
+  await expect(page.getByText("Initial settings created")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
+
+  // Navigate to the service view and confirm the transition.
+  await page.getByRole("link", { name: "Service" }).click();
+  await expect(page).toHaveURL(/#\/service$/);
+  await expect(page.getByRole("heading", { name: "Service Runtime" })).toBeVisible();
+
+  // The REAL backend wrote project.yml under the temp workspace.
+  const projectFile = join(ctx.workspaceDir, ".guildbotics", "config", "team", "project.yml");
+  const projectYaml = readFileSync(projectFile, "utf-8");
+  expect(projectYaml).toContain("language: en");
+  expect(projectYaml).toContain("E2E automation workspace");
+});

--- a/desktop/e2e/start-stack.mjs
+++ b/desktop/e2e/start-stack.mjs
@@ -51,6 +51,11 @@ const backendPort = Number(process.env.GUILDBOTICS_E2E_BACKEND_PORT ?? "8766");
 const frontendPort = Number(process.env.GUILDBOTICS_E2E_FRONTEND_PORT ?? "1421");
 const token = process.env.GUILDBOTICS_E2E_TOKEN ?? "e2e-token";
 const shouldSeed = process.env.GUILDBOTICS_E2E_SEED === "1";
+// Seed with an empty OpenAI API key so the diagnostics journey can verify the
+// missing-key short-circuit WITHOUT firing a live LLM call. Keeps `npm run e2e`
+// fully offline and deterministic (no dependency on api.openai.com latency or
+// availability).
+const seedWithoutLlmKey = process.env.GUILDBOTICS_E2E_OFFLINE_LLM === "1";
 // "down" mode does not start the backend at boot; the spec brings it up later
 // through the control server on GUILDBOTICS_E2E_CONTROL_PORT.
 const deferBackend = process.env.GUILDBOTICS_E2E_DEFER_BACKEND === "1";
@@ -83,6 +88,7 @@ writeFileSync(
       token,
       host,
       seeded: shouldSeed,
+      seededWithoutLlmKey: shouldSeed && seedWithoutLlmKey,
       deferBackend,
       memberId: shouldSeed ? seededMemberId : null,
     },
@@ -95,6 +101,14 @@ const backendEnv = { ...process.env, HOME: homeDir };
 // Force the workspace config layout (`<cwd>/.guildbotics/config`) by removing any
 // inherited override; this yields config-status `primary_config_location=workspace`.
 delete backendEnv.GUILDBOTICS_CONFIG_DIR;
+// Offline-LLM stacks must NOT inherit a developer's real LLM key from the
+// shell; otherwise the diagnostics missing-key short-circuit cannot be
+// asserted deterministically.
+if (seedWithoutLlmKey) {
+  delete backendEnv.OPENAI_API_KEY;
+  delete backendEnv.GOOGLE_API_KEY;
+  delete backendEnv.ANTHROPIC_API_KEY;
+}
 
 let backend;
 let frontend;
@@ -200,7 +214,7 @@ async function seedWorkspace() {
     description: "E2E configured workspace",
     llm_api_type: "openai",
     cli_agent: "codex",
-    openai_api_key: "sk-e2e-test-key",
+    openai_api_key: seedWithoutLlmKey ? "" : "sk-e2e-test-key",
   });
   await postJson("/config/members", {
     config_dir: configDir,

--- a/desktop/e2e/start-stack.mjs
+++ b/desktop/e2e/start-stack.mjs
@@ -1,0 +1,306 @@
+// Launcher for the Playwright E2E stack.
+//
+// Boots the REAL Python Local API backend against a FRESH temp workspace, waits
+// for `/health`, optionally PRE-SEEDS the workspace into a configured project +
+// active member via the real API, then starts Vite in browser-preview mode wired
+// to that backend via VITE_GUILDBOTICS_API_TOKEN / VITE_GUILDBOTICS_API_BASE.
+//
+// Stacks launched in parallel by playwright.config.ts:
+//   * "setup"     — empty workspace, no seeding, so the app lands on first-setup
+//                   (journey ①, `setup.spec.ts`).
+//   * "configured"— seeded workspace (project + active member), so the app boots
+//                   already-configured for the service / commands journeys
+//                   (journeys ③ ④, `service.spec.ts` / `commands.spec.ts`).
+//   * "members"   — seeded workspace dedicated to the member-add journey
+//                   (journey ②, `members.spec.ts`). Isolated from "configured"
+//                   so mutating the member list never perturbs journeys ③ ④.
+//   * "diagnostics"— seeded workspace for the readiness/scenario diagnostics
+//                   journey (journey ⑤, `diagnostics.spec.ts`).
+//   * "down"      — DEFERRED backend: the frontend boots pointed at a backend
+//                   port that is NOT yet serving (journey ⑥, `failure.spec.ts`).
+//                   A small control HTTP server lets the spec bring the real
+//                   backend UP on demand, so backend-down → up is deterministic
+//                   rather than timing-flaky.
+//
+// Each stack owns its OWN temp workspace, HOME, ports, token and stack-context
+// file, so the journeys stay fully isolated and the first-setup spec always sees
+// an empty workspace. The backend cwd is the temp workspace, so `/config/init`
+// writes `<workspace>/.guildbotics/config/...` on disk. HOME is redirected to a
+// second temp dir to keep the run hermetic.
+//
+// Vite runs in the foreground; when Playwright tears the web server down it kills
+// this process group, and the SIGINT/SIGTERM handlers below stop the backend so
+// no orphan uvicorn survives.
+
+import { spawn } from "node:child_process";
+import { createServer } from "node:http";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const desktopDir = resolve(here, "..");
+const repoRoot = resolve(desktopDir, "..");
+
+// Each stack is parameterized through env vars so playwright.config.ts can launch
+// several isolated instances in parallel.
+const stackName = process.env.GUILDBOTICS_E2E_STACK ?? "setup";
+const host = process.env.GUILDBOTICS_E2E_HOST ?? "127.0.0.1";
+const backendPort = Number(process.env.GUILDBOTICS_E2E_BACKEND_PORT ?? "8766");
+const frontendPort = Number(process.env.GUILDBOTICS_E2E_FRONTEND_PORT ?? "1421");
+const token = process.env.GUILDBOTICS_E2E_TOKEN ?? "e2e-token";
+const shouldSeed = process.env.GUILDBOTICS_E2E_SEED === "1";
+// "down" mode does not start the backend at boot; the spec brings it up later
+// through the control server on GUILDBOTICS_E2E_CONTROL_PORT.
+const deferBackend = process.env.GUILDBOTICS_E2E_DEFER_BACKEND === "1";
+const controlPort = Number(process.env.GUILDBOTICS_E2E_CONTROL_PORT ?? "0");
+const contextFile = process.env.GUILDBOTICS_E2E_CONTEXT_FILE ?? ".stack-context.json";
+const baseUrl = `http://${host}:${backendPort}`;
+const authHeaders = { "X-GuildBotics-Session-Token": token, "Content-Type": "application/json" };
+const tag = `[e2e:${stackName}]`;
+
+// Isolated, repeatable run dirs.
+const workspaceDir = mkdtempSync(join(tmpdir(), `guildbotics-e2e-${stackName}-ws-`));
+const homeDir = mkdtempSync(join(tmpdir(), `guildbotics-e2e-${stackName}-home-`));
+const configDir = join(workspaceDir, ".guildbotics", "config");
+const envFile = join(workspaceDir, ".env");
+
+// Publish the run context so specs can read the on-disk project.yml / seeded ids.
+const seededMemberId = "local-agent";
+writeFileSync(
+  join(desktopDir, "e2e", contextFile),
+  JSON.stringify(
+    {
+      stackName,
+      workspaceDir,
+      homeDir,
+      configDir,
+      envFile,
+      backendPort,
+      frontendPort,
+      controlPort,
+      token,
+      host,
+      seeded: shouldSeed,
+      deferBackend,
+      memberId: shouldSeed ? seededMemberId : null,
+    },
+    null,
+    2,
+  ),
+);
+
+const backendEnv = { ...process.env, HOME: homeDir };
+// Force the workspace config layout (`<cwd>/.guildbotics/config`) by removing any
+// inherited override; this yields config-status `primary_config_location=workspace`.
+delete backendEnv.GUILDBOTICS_CONFIG_DIR;
+
+let backend;
+let frontend;
+let controlServer;
+let shuttingDown = false;
+
+function spawnBackend() {
+  return spawn(
+    "uv",
+    [
+      "run",
+      "--project",
+      repoRoot,
+      "python",
+      "-m",
+      "guildbotics.app_api",
+      "--host",
+      host,
+      "--port",
+      String(backendPort),
+      "--token",
+      token,
+    ],
+    { cwd: workspaceDir, env: backendEnv, stdio: "inherit" },
+  );
+}
+
+function attachBackendExitGuard() {
+  backend.on("exit", (code) => {
+    if (!shuttingDown) {
+      console.error(`${tag} backend exited early with code ${code ?? "null"}`);
+      shutdown(1);
+    }
+  });
+}
+
+function shutdown(code) {
+  if (shuttingDown) {
+    return;
+  }
+  shuttingDown = true;
+  if (controlServer) {
+    controlServer.close();
+  }
+  if (frontend && frontend.exitCode === null) {
+    frontend.kill("SIGTERM");
+  }
+  if (backend && backend.exitCode === null) {
+    backend.kill("SIGTERM");
+  }
+  if (typeof code === "number") {
+    setTimeout(() => process.exit(code), 200);
+  }
+}
+
+process.on("SIGINT", () => shutdown(0));
+process.on("SIGTERM", () => shutdown(0));
+process.on("exit", () => shutdown());
+
+async function waitForHealth() {
+  const deadline = Date.now() + 60_000;
+  let lastError = "unknown";
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(`${baseUrl}/health`, { headers: authHeaders });
+      if (response.ok) {
+        return;
+      }
+      lastError = `status ${response.status}`;
+    } catch (error) {
+      lastError = String(error);
+    }
+    await new Promise((r) => setTimeout(r, 300));
+  }
+  throw new Error(`${tag} backend did not become healthy: ${lastError}`);
+}
+
+async function postJson(path, body) {
+  const response = await fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    headers: authHeaders,
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `${tag} POST ${path} failed: status ${response.status} ${await response.text()}`,
+    );
+  }
+  return response.json();
+}
+
+// Seed a configured project + one active member directly through the real API,
+// mirroring how `tests/guildbotics/app_api/test_api_integration.py` provisions a
+// workspace. This makes the app boot on `/service` and `/commands` already wired
+// to a member, and the empty-workspace seeding also creates the sample commands
+// (e.g. `context-info`) used by journey ④.
+async function seedWorkspace() {
+  await postJson("/config/init", {
+    config_dir: configDir,
+    env_file_path: envFile,
+    env_file_option: "overwrite",
+    language: "en",
+    description: "E2E configured workspace",
+    llm_api_type: "openai",
+    cli_agent: "codex",
+    openai_api_key: "sk-e2e-test-key",
+  });
+  await postJson("/config/members", {
+    config_dir: configDir,
+    env_file_path: envFile,
+    person_type: "",
+    person_id: seededMemberId,
+    person_name: "Local Agent",
+    is_active: true,
+    github_username: "",
+    git_email: "",
+    roles: ["architect"],
+    speaking_style: "concise",
+  });
+  console.log(`${tag} seeded configured workspace (workspace=${workspaceDir})`);
+}
+
+function startFrontend() {
+  frontend = spawn(
+    "npm",
+    ["run", "dev", "--", "--host", host, "--port", String(frontendPort), "--strictPort"],
+    {
+      cwd: desktopDir,
+      env: {
+        ...process.env,
+        VITE_GUILDBOTICS_API_TOKEN: token,
+        VITE_GUILDBOTICS_API_BASE: baseUrl,
+      },
+      stdio: "inherit",
+    },
+  );
+
+  frontend.on("exit", (code) => {
+    shutdown(code ?? 0);
+  });
+}
+
+// Control server for the "down" journey (⑥). The frontend is started pointed at a
+// backend port that is NOT yet serving, so the app boots into Bootstrap's error
+// state. The spec then POSTs `/control/start-backend` here; we start the REAL
+// backend, wait for `/health`, and only then answer 200 — so the subsequent
+// retry click in the app is guaranteed to find a healthy backend (no race).
+function startControlServer() {
+  let backendStarting = false;
+  controlServer = createServer((req, res) => {
+    if (req.method === "POST" && req.url === "/control/start-backend") {
+      if (backend) {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ status: "already-running" }));
+        return;
+      }
+      if (backendStarting) {
+        res.writeHead(409, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ status: "starting" }));
+        return;
+      }
+      backendStarting = true;
+      console.log(`${tag} control: starting backend on demand`);
+      backend = spawnBackend();
+      attachBackendExitGuard();
+      waitForHealth()
+        .then(() => {
+          console.log(`${tag} control: backend healthy at ${baseUrl}`);
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ status: "ready" }));
+        })
+        .catch((error) => {
+          res.writeHead(500, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ status: "error", error: String(error) }));
+        });
+      return;
+    }
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ status: "not-found" }));
+  });
+  controlServer.listen(controlPort, host, () => {
+    console.log(`${tag} control server listening on http://${host}:${controlPort}`);
+  });
+}
+
+async function main() {
+  if (deferBackend) {
+    // Backend stays DOWN until the spec asks the control server to start it.
+    startControlServer();
+    startFrontend();
+    return;
+  }
+
+  backend = spawnBackend();
+  attachBackendExitGuard();
+  await waitForHealth();
+  console.log(`${tag} backend healthy at ${baseUrl} (workspace=${workspaceDir})`);
+
+  if (shouldSeed) {
+    await seedWorkspace();
+  }
+
+  startFrontend();
+}
+
+main().catch((error) => {
+  console.error(error);
+  shutdown(1);
+});

--- a/desktop/eslint.config.js
+++ b/desktop/eslint.config.js
@@ -31,4 +31,14 @@ export default tseslint.config(
       ...reactHooks.configs.recommended.rules,
     },
   },
+  {
+    // The Playwright E2E harness runs in Node (launcher script + specs that touch
+    // the filesystem), so give those files Node globals instead of browser ones.
+    files: ["e2e/**/*.{ts,mjs}", "playwright.config.ts"],
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: "module",
+      globals: { ...globals.node, fetch: "readonly" },
+    },
+  },
 );

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -26,6 +26,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@playwright/test": "^1.60.0",
         "@tauri-apps/cli": "2.5.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -1362,6 +1363,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@remix-run/router": {
@@ -4444,6 +4461,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -14,6 +14,8 @@
     "duplicates": "jscpd --config jscpd.config.json",
     "test": "vitest run",
     "test:watch": "vitest",
+    "e2e": "playwright test",
+    "e2e:install": "playwright install chromium",
     "quality": "npm run format:check && npm run lint && npm run typecheck && npm run duplicates && npm run test",
     "tauri": "tauri"
   },
@@ -36,6 +38,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@playwright/test": "^1.60.0",
     "@tauri-apps/cli": "2.5.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -1,0 +1,189 @@
+import { defineConfig, devices } from "@playwright/test";
+
+// Real-browser E2E layer for the desktop app. Each run boots the REAL Python
+// Local API backend against a fresh temp workspace and a Vite dev server wired to
+// it in browser-preview mode (no Tauri). See `e2e/start-stack.mjs` for the
+// harness that owns process lifecycle and the isolated workspace.
+//
+// Five fully isolated stacks run in parallel, each matched to its spec by
+// filename via `testMatch`:
+//   * "setup"       — empty workspace (first-setup journey ①, `setup.spec.ts`).
+//   * "configured"  — pre-seeded project + active member (service / commands
+//                     journeys ③ ④, `service.spec.ts` / `commands.spec.ts`).
+//   * "members"     — pre-seeded workspace dedicated to the member-add journey
+//                     (journey ②, `members.spec.ts`); isolated from "configured"
+//                     so mutating the member list never perturbs ③ ④.
+//   * "diagnostics" — pre-seeded workspace for the readiness / scenario
+//                     diagnostics journey (journey ⑤, `diagnostics.spec.ts`).
+//   * "down"        — frontend booted against a NOT-yet-serving backend; the
+//                     spec brings the real backend up on demand via a control
+//                     server (critical-failure journey ⑥, `failure.spec.ts`).
+// Each stack owns its own backend port, frontend port, token and on-disk
+// workspace, so the journeys never share state.
+
+const HOST = process.env.GUILDBOTICS_E2E_HOST ?? "127.0.0.1";
+
+const SETUP_BACKEND_PORT = Number(process.env.GUILDBOTICS_E2E_BACKEND_PORT ?? "8766");
+const SETUP_FRONTEND_PORT = Number(process.env.GUILDBOTICS_E2E_FRONTEND_PORT ?? "1421");
+const CONFIGURED_BACKEND_PORT = Number(
+  process.env.GUILDBOTICS_E2E_CONFIGURED_BACKEND_PORT ?? "8767",
+);
+const CONFIGURED_FRONTEND_PORT = Number(
+  process.env.GUILDBOTICS_E2E_CONFIGURED_FRONTEND_PORT ?? "1422",
+);
+const MEMBERS_BACKEND_PORT = Number(process.env.GUILDBOTICS_E2E_MEMBERS_BACKEND_PORT ?? "8768");
+const MEMBERS_FRONTEND_PORT = Number(process.env.GUILDBOTICS_E2E_MEMBERS_FRONTEND_PORT ?? "1423");
+const DIAGNOSTICS_BACKEND_PORT = Number(
+  process.env.GUILDBOTICS_E2E_DIAGNOSTICS_BACKEND_PORT ?? "8769",
+);
+const DIAGNOSTICS_FRONTEND_PORT = Number(
+  process.env.GUILDBOTICS_E2E_DIAGNOSTICS_FRONTEND_PORT ?? "1424",
+);
+const DOWN_BACKEND_PORT = Number(process.env.GUILDBOTICS_E2E_DOWN_BACKEND_PORT ?? "8770");
+const DOWN_FRONTEND_PORT = Number(process.env.GUILDBOTICS_E2E_DOWN_FRONTEND_PORT ?? "1425");
+const DOWN_CONTROL_PORT = Number(process.env.GUILDBOTICS_E2E_DOWN_CONTROL_PORT ?? "8771");
+
+const SETUP_BASE_URL = `http://${HOST}:${SETUP_FRONTEND_PORT}`;
+const CONFIGURED_BASE_URL = `http://${HOST}:${CONFIGURED_FRONTEND_PORT}`;
+const MEMBERS_BASE_URL = `http://${HOST}:${MEMBERS_FRONTEND_PORT}`;
+const DIAGNOSTICS_BASE_URL = `http://${HOST}:${DIAGNOSTICS_FRONTEND_PORT}`;
+const DOWN_BASE_URL = `http://${HOST}:${DOWN_FRONTEND_PORT}`;
+
+const SETUP_TOKEN = "e2e-token-setup";
+const CONFIGURED_TOKEN = "e2e-token-configured";
+const MEMBERS_TOKEN = "e2e-token-members";
+const DIAGNOSTICS_TOKEN = "e2e-token-diagnostics";
+const DOWN_TOKEN = "e2e-token-down";
+
+export default defineConfig({
+  testDir: "e2e",
+  fullyParallel: false,
+  forbidOnly: Boolean(process.env.CI),
+  retries: 0,
+  workers: 1,
+  reporter: process.env.CI ? "line" : "list",
+  timeout: 60_000,
+  expect: { timeout: 15_000 },
+  use: {
+    headless: true,
+    locale: "en-US",
+    trace: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "setup",
+      testMatch: /setup\.spec\.ts$/,
+      use: { ...devices["Desktop Chrome"], baseURL: SETUP_BASE_URL },
+    },
+    {
+      name: "configured",
+      testMatch: /(service|commands)\.spec\.ts$/,
+      use: { ...devices["Desktop Chrome"], baseURL: CONFIGURED_BASE_URL },
+    },
+    {
+      name: "members",
+      testMatch: /members\.spec\.ts$/,
+      use: { ...devices["Desktop Chrome"], baseURL: MEMBERS_BASE_URL },
+    },
+    {
+      name: "diagnostics",
+      testMatch: /diagnostics\.spec\.ts$/,
+      use: { ...devices["Desktop Chrome"], baseURL: DIAGNOSTICS_BASE_URL },
+    },
+    {
+      name: "down",
+      testMatch: /failure\.spec\.ts$/,
+      use: { ...devices["Desktop Chrome"], baseURL: DOWN_BASE_URL },
+    },
+  ],
+  webServer: [
+    {
+      command: "node e2e/start-stack.mjs",
+      url: `${SETUP_BASE_URL}/`,
+      reuseExistingServer: false,
+      timeout: 120_000,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        GUILDBOTICS_E2E_STACK: "setup",
+        GUILDBOTICS_E2E_HOST: HOST,
+        GUILDBOTICS_E2E_BACKEND_PORT: String(SETUP_BACKEND_PORT),
+        GUILDBOTICS_E2E_FRONTEND_PORT: String(SETUP_FRONTEND_PORT),
+        GUILDBOTICS_E2E_TOKEN: SETUP_TOKEN,
+        GUILDBOTICS_E2E_CONTEXT_FILE: ".stack-context.json",
+      },
+    },
+    {
+      command: "node e2e/start-stack.mjs",
+      url: `${CONFIGURED_BASE_URL}/`,
+      reuseExistingServer: false,
+      timeout: 120_000,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        GUILDBOTICS_E2E_STACK: "configured",
+        GUILDBOTICS_E2E_SEED: "1",
+        GUILDBOTICS_E2E_HOST: HOST,
+        GUILDBOTICS_E2E_BACKEND_PORT: String(CONFIGURED_BACKEND_PORT),
+        GUILDBOTICS_E2E_FRONTEND_PORT: String(CONFIGURED_FRONTEND_PORT),
+        GUILDBOTICS_E2E_TOKEN: CONFIGURED_TOKEN,
+        GUILDBOTICS_E2E_CONTEXT_FILE: ".stack-context-configured.json",
+      },
+    },
+    {
+      command: "node e2e/start-stack.mjs",
+      url: `${MEMBERS_BASE_URL}/`,
+      reuseExistingServer: false,
+      timeout: 120_000,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        GUILDBOTICS_E2E_STACK: "members",
+        GUILDBOTICS_E2E_SEED: "1",
+        GUILDBOTICS_E2E_HOST: HOST,
+        GUILDBOTICS_E2E_BACKEND_PORT: String(MEMBERS_BACKEND_PORT),
+        GUILDBOTICS_E2E_FRONTEND_PORT: String(MEMBERS_FRONTEND_PORT),
+        GUILDBOTICS_E2E_TOKEN: MEMBERS_TOKEN,
+        GUILDBOTICS_E2E_CONTEXT_FILE: ".stack-context-members.json",
+      },
+    },
+    {
+      command: "node e2e/start-stack.mjs",
+      url: `${DIAGNOSTICS_BASE_URL}/`,
+      reuseExistingServer: false,
+      timeout: 120_000,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        GUILDBOTICS_E2E_STACK: "diagnostics",
+        GUILDBOTICS_E2E_SEED: "1",
+        GUILDBOTICS_E2E_HOST: HOST,
+        GUILDBOTICS_E2E_BACKEND_PORT: String(DIAGNOSTICS_BACKEND_PORT),
+        GUILDBOTICS_E2E_FRONTEND_PORT: String(DIAGNOSTICS_FRONTEND_PORT),
+        GUILDBOTICS_E2E_TOKEN: DIAGNOSTICS_TOKEN,
+        GUILDBOTICS_E2E_CONTEXT_FILE: ".stack-context-diagnostics.json",
+      },
+    },
+    {
+      // Journey ⑥: the frontend boots pointed at DOWN_BACKEND_PORT, which is not
+      // serving yet. Playwright waits on the FRONTEND url (always up), and the
+      // spec uses the control server to start the backend before its retry.
+      command: "node e2e/start-stack.mjs",
+      url: `${DOWN_BASE_URL}/`,
+      reuseExistingServer: false,
+      timeout: 120_000,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        GUILDBOTICS_E2E_STACK: "down",
+        GUILDBOTICS_E2E_DEFER_BACKEND: "1",
+        GUILDBOTICS_E2E_HOST: HOST,
+        GUILDBOTICS_E2E_BACKEND_PORT: String(DOWN_BACKEND_PORT),
+        GUILDBOTICS_E2E_FRONTEND_PORT: String(DOWN_FRONTEND_PORT),
+        GUILDBOTICS_E2E_CONTROL_PORT: String(DOWN_CONTROL_PORT),
+        GUILDBOTICS_E2E_TOKEN: DOWN_TOKEN,
+        GUILDBOTICS_E2E_CONTEXT_FILE: ".stack-context-down.json",
+      },
+    },
+  ],
+});

--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -157,6 +157,11 @@ export default defineConfig({
       env: {
         GUILDBOTICS_E2E_STACK: "diagnostics",
         GUILDBOTICS_E2E_SEED: "1",
+        // Seed without an LLM API key so the diagnostics journey can verify
+        // the backend's missing-key short-circuit deterministically, with NO
+        // live OpenAI round-trip. Keeps `npm run e2e` offline-safe and avoids
+        // flakiness from external network / provider latency.
+        GUILDBOTICS_E2E_OFFLINE_LLM: "1",
         GUILDBOTICS_E2E_HOST: HOST,
         GUILDBOTICS_E2E_BACKEND_PORT: String(DIAGNOSTICS_BACKEND_PORT),
         GUILDBOTICS_E2E_FRONTEND_PORT: String(DIAGNOSTICS_FRONTEND_PORT),

--- a/desktop/src/App.test.tsx
+++ b/desktop/src/App.test.tsx
@@ -1,13 +1,60 @@
 import { MantineProvider, createTheme } from "@mantine/core";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
+import type { TFunction } from "i18next";
 import { HashRouter } from "react-router-dom";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { App } from "./App";
-import type { PromptTraceEntry } from "./api/client";
+import {
+  App,
+  buildCommandArgs,
+  commandFailureDetail,
+  decodeTraceText,
+  eventBadgeColor,
+  eventTypeLabel,
+  formatCommandEvent,
+  formatRuntimeEvent,
+  isStopTimeoutPending,
+  localFileHref,
+  logBadgeColor,
+  matchesFeedFilter,
+  matchesLogFilter,
+  openLocalFile,
+  selectTraceFile,
+  splitCommandLine,
+  traceBrainLabel,
+  traceFieldRows,
+  traceGroupMetadata,
+  upsertCommandRecord,
+  type CommandRunRecord,
+} from "./App";
+import type {
+  CommandOption,
+  PromptTraceEntry,
+  RuntimeEvent,
+  RuntimeLog,
+  RuntimeUnitStatus,
+} from "./api/client";
+import i18n from "./i18n";
 import "./i18n";
-import { buildTraceGroups } from "./trace";
+import { buildTraceGroups, type PromptTraceGroup } from "./trace";
+
+const openShell = vi.fn();
+const openDialog = vi.fn();
+const saveDialog = vi.fn();
+
+vi.mock("@tauri-apps/plugin-shell", () => ({
+  open: (path: string) => openShell(path),
+}));
+
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  open: (options: unknown) => openDialog(options),
+  save: (options: unknown) => saveDialog(options),
+}));
+
+function t(): TFunction {
+  return i18n.getFixedT("en") as TFunction;
+}
 
 vi.mock("./setup/SetupPage", () => ({
   SetupPage: () => <div>Setup Mock</div>,
@@ -138,6 +185,450 @@ describe("buildTraceGroups", () => {
   });
 });
 
+describe("buildCommandArgs", () => {
+  function option(overrides: Partial<CommandOption> = {}): CommandOption {
+    return {
+      command: "demo",
+      label: "Demo",
+      description: "",
+      category: "function",
+      source: "workspace",
+      path: "/cmd.py",
+      arguments: [],
+      supports_raw_args: true,
+      recommended_input: "",
+      requirements: [],
+      ...overrides,
+    };
+  }
+
+  it("builds positional args and keyword args from option values", () => {
+    const opt = option({
+      arguments: [
+        { name: "first", kind: "positional", required: true, default: "" },
+        { name: "mode", kind: "keyword", required: false, default: "" },
+      ],
+    });
+
+    const args = buildCommandArgs(opt, { first: " hello ", mode: "fast" }, "");
+
+    expect(args).toEqual(["hello", "mode=fast"]);
+  });
+
+  it("skips empty or whitespace-only values", () => {
+    const opt = option({
+      arguments: [
+        { name: "first", kind: "positional", required: true, default: "" },
+        { name: "mode", kind: "keyword", required: false, default: "" },
+      ],
+    });
+
+    const args = buildCommandArgs(opt, { first: "", mode: "   " }, "");
+
+    expect(args).toEqual([]);
+  });
+
+  it("appends parsed raw args after structured args", () => {
+    const opt = option({
+      arguments: [{ name: "first", kind: "positional", required: true, default: "" }],
+    });
+
+    const args = buildCommandArgs(opt, { first: "x" }, 'a "b c" key=value');
+
+    expect(args).toEqual(["x", "a", "b c", "key=value"]);
+  });
+
+  it("returns only raw args when no option is selected", () => {
+    expect(buildCommandArgs(null, { ignored: "x" }, "raw")).toEqual(["raw"]);
+  });
+});
+
+describe("splitCommandLine", () => {
+  it("splits on whitespace", () => {
+    expect(splitCommandLine("a b   c")).toEqual(["a", "b", "c"]);
+  });
+
+  it("preserves double-quoted segments", () => {
+    expect(splitCommandLine('a "b c" d')).toEqual(["a", "b c", "d"]);
+  });
+
+  it("preserves single-quoted segments", () => {
+    expect(splitCommandLine("a 'b c' d")).toEqual(["a", "b c", "d"]);
+  });
+
+  it("returns an empty array for empty input", () => {
+    expect(splitCommandLine("")).toEqual([]);
+    expect(splitCommandLine("   ")).toEqual([]);
+  });
+});
+
+describe("upsertCommandRecord", () => {
+  function record(overrides: Partial<CommandRunRecord>): CommandRunRecord {
+    return {
+      requestId: "req-1",
+      person: "alice",
+      command: "demo",
+      startedAt: "2026-06-04T01:00:00Z",
+      status: "running",
+      ...overrides,
+    };
+  }
+
+  it("prepends a new request", () => {
+    const existing = [record({ requestId: "req-0", startedAt: "2026-06-04T00:00:00Z" })];
+
+    const next = upsertCommandRecord(existing, record({ requestId: "req-1" }));
+
+    expect(next.map((entry) => entry.requestId)).toEqual(["req-1", "req-0"]);
+  });
+
+  it("updates an existing request and keeps prior output when not provided", () => {
+    const existing = [record({ requestId: "req-1", status: "running", output: "partial" })];
+
+    const next = upsertCommandRecord(existing, record({ requestId: "req-1", status: "success" }));
+
+    expect(next).toHaveLength(1);
+    expect(next[0]).toMatchObject({ status: "success", output: "partial" });
+  });
+
+  it("sorts records by startedAt descending and caps at 20", () => {
+    const many = Array.from({ length: 25 }, (_, index) =>
+      record({
+        requestId: `req-${index}`,
+        startedAt: `2026-06-04T00:${String(index).padStart(2, "0")}:00Z`,
+      }),
+    );
+
+    const next = upsertCommandRecord([], many[0]);
+    const filled = many.slice(1).reduce((acc, item) => upsertCommandRecord(acc, item), next);
+
+    expect(filled).toHaveLength(20);
+    expect(filled[0]?.requestId).toBe("req-24");
+  });
+});
+
+describe("commandFailureDetail", () => {
+  it("serializes request id, type, and payload as pretty JSON", () => {
+    const detail = commandFailureDetail(
+      runtimeEvent({
+        type: "command.failed",
+        request_id: "req-9",
+        payload: { code: "boom", message: "oops" },
+      }),
+    );
+
+    expect(JSON.parse(detail)).toEqual({
+      request_id: "req-9",
+      type: "command.failed",
+      payload: { code: "boom", message: "oops" },
+    });
+    expect(detail).toContain("\n");
+  });
+});
+
+describe("formatCommandEvent", () => {
+  it("prefers payload.message", () => {
+    expect(formatCommandEvent(runtimeEvent({ payload: { message: "hi", command: "demo" } }))).toBe(
+      "hi",
+    );
+  });
+
+  it("falls back to payload.command", () => {
+    expect(formatCommandEvent(runtimeEvent({ payload: { command: "demo" } }))).toBe("demo");
+  });
+
+  it("falls back to request id then type", () => {
+    expect(formatCommandEvent(runtimeEvent({ request_id: "req-7", payload: {} }))).toBe("req-7");
+    expect(
+      formatCommandEvent(runtimeEvent({ type: "command.failed", request_id: null, payload: {} })),
+    ).toBe("command.failed");
+  });
+});
+
+describe("matchesFeedFilter", () => {
+  it("passes everything for all", () => {
+    expect(matchesFeedFilter(runtimeEvent({ type: "scheduler.running" }), "all")).toBe(true);
+  });
+
+  it("matches failed or error events for the error filter", () => {
+    expect(matchesFeedFilter(runtimeEvent({ type: "command.failed" }), "error")).toBe(true);
+    expect(matchesFeedFilter(runtimeEvent({ type: "runtime.error" }), "error")).toBe(true);
+    expect(matchesFeedFilter(runtimeEvent({ type: "command.finished" }), "error")).toBe(false);
+  });
+
+  it("matches by event prefix for command/scheduler/events filters", () => {
+    expect(matchesFeedFilter(runtimeEvent({ type: "command.started" }), "command")).toBe(true);
+    expect(matchesFeedFilter(runtimeEvent({ type: "scheduler.running" }), "scheduler")).toBe(true);
+    expect(matchesFeedFilter(runtimeEvent({ type: "events.running" }), "events")).toBe(true);
+    expect(matchesFeedFilter(runtimeEvent({ type: "scheduler.running" }), "command")).toBe(false);
+  });
+});
+
+describe("matchesLogFilter", () => {
+  function log(overrides: Partial<RuntimeLog>): RuntimeLog {
+    return {
+      level: "INFO",
+      message: "hello world",
+      request_id: null,
+      timestamp: "2026-06-04T01:00:00Z",
+      ...overrides,
+    };
+  }
+
+  it("passes everything for all", () => {
+    expect(matchesLogFilter(log({}), "all")).toBe(true);
+  });
+
+  it("matches error-level logs for the error filter", () => {
+    expect(matchesLogFilter(log({ level: "error" }), "error")).toBe(true);
+    expect(matchesLogFilter(log({ level: "WARNING" }), "error")).toBe(true);
+    expect(matchesLogFilter(log({ level: "INFO" }), "error")).toBe(false);
+  });
+
+  it("matches logs with a request id for the command filter", () => {
+    expect(matchesLogFilter(log({ request_id: "req-1" }), "command")).toBe(true);
+    expect(matchesLogFilter(log({ request_id: null }), "command")).toBe(false);
+  });
+
+  it("falls back to a message substring match", () => {
+    expect(matchesLogFilter(log({ message: "Hello World" }), "world")).toBe(true);
+    expect(matchesLogFilter(log({ message: "nope" }), "world")).toBe(false);
+  });
+});
+
+describe("eventTypeLabel", () => {
+  it("labels command events from the command_ namespace", () => {
+    expect(eventTypeLabel(t(), "command.started")).toBe(
+      i18n.t("overview.eventTypes.command_started", { lng: "en" }),
+    );
+    expect(eventTypeLabel(t(), "command.finished")).toBe(
+      i18n.t("overview.eventTypes.command_finished", { lng: "en" }),
+    );
+  });
+
+  it("labels scheduler and events families", () => {
+    expect(eventTypeLabel(t(), "scheduler.running")).toBe(
+      i18n.t("overview.eventTypes.scheduler", { lng: "en" }),
+    );
+    expect(eventTypeLabel(t(), "events.stopped")).toBe(
+      i18n.t("overview.eventTypes.events", { lng: "en" }),
+    );
+  });
+
+  it("returns the raw type for unknown families", () => {
+    expect(eventTypeLabel(t(), "mystery.thing")).toBe("mystery.thing");
+  });
+});
+
+describe("badge colors", () => {
+  it("maps event types to colors", () => {
+    expect(eventBadgeColor("command.failed")).toBe("red");
+    expect(eventBadgeColor("scheduler.running")).toBe("teal");
+    expect(eventBadgeColor("command.started")).toBe("teal");
+    expect(eventBadgeColor("command.finished")).toBe("teal");
+    expect(eventBadgeColor("scheduler.stopping")).toBe("orange");
+    expect(eventBadgeColor("scheduler.stopped")).toBe("gray");
+  });
+
+  it("maps log levels to colors", () => {
+    expect(logBadgeColor("error")).toBe("red");
+    expect(logBadgeColor("CRITICAL")).toBe("red");
+    expect(logBadgeColor("warning")).toBe("orange");
+    expect(logBadgeColor("info")).toBe("gray");
+  });
+});
+
+describe("formatRuntimeEvent", () => {
+  it("prefers payload message", () => {
+    expect(formatRuntimeEvent(t(), runtimeEvent({ payload: { message: "hi" } }))).toBe("hi");
+  });
+
+  it("formats a command summary from payload.command", () => {
+    expect(formatRuntimeEvent(t(), runtimeEvent({ payload: { command: "demo" } }))).toBe(
+      i18n.t("overview.eventSummaries.command", { command: "demo", lng: "en" }),
+    );
+  });
+
+  it("prefers payload.error over family summaries", () => {
+    expect(
+      formatRuntimeEvent(t(), runtimeEvent({ type: "scheduler.running", payload: { error: "x" } })),
+    ).toBe("x");
+  });
+
+  it("returns family summaries when payload is empty", () => {
+    expect(formatRuntimeEvent(t(), runtimeEvent({ type: "scheduler.running", payload: {} }))).toBe(
+      i18n.t("overview.eventSummaries.schedulerRunning", { lng: "en" }),
+    );
+    expect(formatRuntimeEvent(t(), runtimeEvent({ type: "events.stopped", payload: {} }))).toBe(
+      i18n.t("overview.eventSummaries.eventsStopped", { lng: "en" }),
+    );
+    expect(formatRuntimeEvent(t(), runtimeEvent({ type: "scheduler.failed", payload: {} }))).toBe(
+      i18n.t("overview.eventSummaries.failed", { lng: "en" }),
+    );
+  });
+
+  it("returns the raw type when nothing else matches", () => {
+    expect(formatRuntimeEvent(t(), runtimeEvent({ type: "weird.thing", payload: {} }))).toBe(
+      "weird.thing",
+    );
+  });
+});
+
+describe("isStopTimeoutPending", () => {
+  function unit(overrides: Partial<RuntimeUnitStatus>): RuntimeUnitStatus {
+    return { ...runtimeUnit("scheduler"), ...overrides };
+  }
+
+  it("is true when a failed unit is still running due to stop timeout", () => {
+    expect(
+      isStopTimeoutPending(
+        unit({ running: true, state: "failed", error: "worker did not stop before timeout" }),
+      ),
+    ).toBe(true);
+  });
+
+  it("is false when not running, not failed, or error unrelated", () => {
+    expect(isStopTimeoutPending(undefined)).toBe(false);
+    expect(
+      isStopTimeoutPending(
+        unit({ running: false, state: "failed", error: "did not stop before timeout" }),
+      ),
+    ).toBe(false);
+    expect(
+      isStopTimeoutPending(
+        unit({ running: true, state: "running", error: "did not stop before timeout" }),
+      ),
+    ).toBe(false);
+    expect(isStopTimeoutPending(unit({ running: true, state: "failed", error: "other" }))).toBe(
+      false,
+    );
+  });
+});
+
+describe("decodeTraceText", () => {
+  it("decodes unicode escapes, newlines, and tabs", () => {
+    expect(decodeTraceText("a\\nb\\tc")).toBe("a\nb\tc");
+    expect(decodeTraceText("\\u3042")).toBe("あ");
+  });
+
+  it("leaves plain text untouched", () => {
+    expect(decodeTraceText("plain text")).toBe("plain text");
+  });
+});
+
+describe("traceBrainLabel", () => {
+  it("returns the file stem of a brain path", () => {
+    expect(traceBrainLabel("brains/default.yml")).toBe("default");
+    expect(traceBrainLabel("nested/dir/coder.yaml")).toBe("coder");
+  });
+
+  it("returns a dash for an empty brain", () => {
+    expect(traceBrainLabel("")).toBe("-");
+  });
+});
+
+describe("traceFieldRows", () => {
+  it("includes base fields and extra string/number/boolean fields", () => {
+    const rows = traceFieldRows(
+      traceEntry({
+        brain: "brains/default.yml",
+        command: "demo",
+        target: "",
+        cwd: "/workspace",
+        fields: { model: "gpt", count: 3, flag: true, obj: { a: 1 } },
+      }),
+    );
+
+    expect(rows).toContainEqual(["brain", "brains/default.yml"]);
+    expect(rows).toContainEqual(["command", "demo"]);
+    expect(rows).toContainEqual(["cwd", "/workspace"]);
+    expect(rows).toContainEqual(["model", "gpt"]);
+    expect(rows).toContainEqual(["count", "3"]);
+    expect(rows).toContainEqual(["flag", "true"]);
+    expect(rows.some(([label]) => label === "obj")).toBe(false);
+    expect(rows.some(([label]) => label === "target")).toBe(false);
+  });
+
+  it("does not duplicate a field already present as a base field", () => {
+    const rows = traceFieldRows(
+      traceEntry({ brain: "brains/default.yml", fields: { brain: "override" } }),
+    );
+
+    expect(rows.filter(([label]) => label === "brain")).toHaveLength(1);
+    expect(rows).toContainEqual(["brain", "brains/default.yml"]);
+  });
+});
+
+describe("traceGroupMetadata", () => {
+  function group(overrides: Partial<PromptTraceGroup>): PromptTraceGroup {
+    return {
+      id: "g1",
+      kind: "llm",
+      request: null,
+      response: null,
+      single: null,
+      timestamp: "2026-06-04T01:00:00Z",
+      personId: "alice",
+      brain: "brains/default.yml",
+      ...overrides,
+    };
+  }
+
+  it("merges request and response field rows and adds the decoded brain", () => {
+    const rows = traceGroupMetadata(
+      group({
+        request: traceEntry({ command: "demo", fields: { model: "gpt" } }),
+        response: traceEntry({ fields: { tokens: 12 } }),
+      }),
+    );
+
+    const map = new Map(rows);
+    expect(map.get("command")).toBe("demo");
+    expect(map.get("model")).toBe("gpt");
+    expect(map.get("tokens")).toBe("12");
+    expect(map.get("brain")).toBe("brains/default.yml");
+  });
+});
+
+describe("localFileHref", () => {
+  it("builds a file URL for an absolute POSIX path", () => {
+    expect(localFileHref("/workspace/trace.log")).toBe("file:///workspace/trace.log");
+  });
+
+  it("builds a file URL for a relative path", () => {
+    expect(localFileHref("logs/trace.log")).toBe("file:///logs/trace.log");
+  });
+
+  it("normalizes Windows backslashes and encodes spaces", () => {
+    expect(localFileHref("C:\\Users\\a b\\trace.log")).toBe("file:///C:/Users/a%20b/trace.log");
+  });
+});
+
+describe("file helpers outside Tauri runtime", () => {
+  beforeEach(() => {
+    openShell.mockClear();
+    openDialog.mockClear();
+    saveDialog.mockClear();
+    delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__;
+  });
+
+  afterEach(() => {
+    delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__;
+  });
+
+  it("openLocalFile is a no-op when not in Tauri", async () => {
+    await openLocalFile("/workspace/trace.log");
+    expect(openShell).not.toHaveBeenCalled();
+  });
+
+  it("selectTraceFile resolves to null when not in Tauri", async () => {
+    await expect(selectTraceFile("open", "/workspace/trace.log")).resolves.toBeNull();
+    await expect(selectTraceFile("save", "/workspace/trace.log")).resolves.toBeNull();
+    expect(openDialog).not.toHaveBeenCalled();
+    expect(saveDialog).not.toHaveBeenCalled();
+  });
+});
+
 function renderApp() {
   const theme = createTheme({
     primaryColor: "dark",
@@ -157,7 +648,7 @@ function renderApp() {
   );
 }
 
-function runtimeUnit(target: "scheduler" | "events") {
+function runtimeUnit(target: "scheduler" | "events"): RuntimeUnitStatus {
   return {
     target,
     state: "stopped",
@@ -178,6 +669,16 @@ function runtimeUnit(target: "scheduler" | "events") {
     events_drained_count: 0,
     events_delivered_count: 0,
     events_skipped_processed_count: 0,
+  };
+}
+
+function runtimeEvent(overrides: Partial<RuntimeEvent>): RuntimeEvent {
+  return {
+    type: "command.started",
+    request_id: "req-1",
+    payload: {},
+    timestamp: "2026-06-04T01:00:00Z",
+    ...overrides,
   };
 }
 

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -1131,7 +1131,7 @@ function RuntimeStateBadge({ state }: { state: RuntimeUnitStatus["state"] }) {
   );
 }
 
-function isStopTimeoutPending(unit: RuntimeUnitStatus | undefined) {
+export function isStopTimeoutPending(unit: RuntimeUnitStatus | undefined) {
   return Boolean(
     unit?.running && unit.state === "failed" && unit.error?.includes("did not stop before timeout"),
   );
@@ -1305,7 +1305,7 @@ function traceKindColor(kind: string) {
   return "gray";
 }
 
-function traceBrainLabel(brain: string) {
+export function traceBrainLabel(brain: string) {
   return (
     brain
       .split("/")
@@ -1314,7 +1314,7 @@ function traceBrainLabel(brain: string) {
   );
 }
 
-function traceGroupMetadata(group: PromptTraceGroup): Array<[string, string]> {
+export function traceGroupMetadata(group: PromptTraceGroup): Array<[string, string]> {
   const rows = new Map<string, string>();
   for (const entry of [group.request, group.response, group.single]) {
     if (!entry) {
@@ -1330,7 +1330,7 @@ function traceGroupMetadata(group: PromptTraceGroup): Array<[string, string]> {
   return Array.from(rows.entries()).slice(0, 10);
 }
 
-function traceFieldRows(entry: PromptTraceEntry): Array<[string, string]> {
+export function traceFieldRows(entry: PromptTraceEntry): Array<[string, string]> {
   const rows: Array<[string, string]> = [];
   for (const [label, value] of [
     ["brain", entry.brain],
@@ -1353,7 +1353,7 @@ function traceFieldRows(entry: PromptTraceEntry): Array<[string, string]> {
   return rows.slice(0, 8);
 }
 
-function decodeTraceText(value: string) {
+export function decodeTraceText(value: string) {
   return value
     .replace(/\\u([0-9a-fA-F]{4})/g, (_, hex: string) =>
       String.fromCharCode(Number.parseInt(hex, 16)),
@@ -1380,7 +1380,7 @@ function formatTime(value: string) {
   }).format(new Date(value));
 }
 
-function matchesFeedFilter(event: RuntimeEvent, filter: string) {
+export function matchesFeedFilter(event: RuntimeEvent, filter: string) {
   if (filter === "all") {
     return true;
   }
@@ -1399,7 +1399,7 @@ function matchesFeedFilter(event: RuntimeEvent, filter: string) {
   return true;
 }
 
-function matchesLogFilter(log: RuntimeLog, filter: string) {
+export function matchesLogFilter(log: RuntimeLog, filter: string) {
   if (filter === "all") {
     return true;
   }
@@ -1412,7 +1412,7 @@ function matchesLogFilter(log: RuntimeLog, filter: string) {
   return log.message.toLowerCase().includes(filter);
 }
 
-function eventTypeLabel(t: TFunction, type: string) {
+export function eventTypeLabel(t: TFunction, type: string) {
   if (type.startsWith("command.")) {
     return t(`overview.eventTypes.${type.replace("command.", "command_")}`, {
       defaultValue: type.replace("command.", ""),
@@ -1427,7 +1427,7 @@ function eventTypeLabel(t: TFunction, type: string) {
   return type;
 }
 
-function eventBadgeColor(type: string) {
+export function eventBadgeColor(type: string) {
   if (type.endsWith(".failed")) {
     return "red";
   }
@@ -1440,7 +1440,7 @@ function eventBadgeColor(type: string) {
   return "gray";
 }
 
-function logBadgeColor(level: string) {
+export function logBadgeColor(level: string) {
   const upper = level.toUpperCase();
   if (upper === "ERROR" || upper === "CRITICAL") {
     return "red";
@@ -1451,7 +1451,7 @@ function logBadgeColor(level: string) {
   return "gray";
 }
 
-function formatRuntimeEvent(t: TFunction, event: RuntimeEvent): string {
+export function formatRuntimeEvent(t: TFunction, event: RuntimeEvent): string {
   const { payload } = event;
   if (typeof payload.message === "string") {
     return payload.message;
@@ -1484,7 +1484,7 @@ function isTauriRuntime() {
   return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
 }
 
-async function openLocalFile(path: string) {
+export async function openLocalFile(path: string) {
   if (!isTauriRuntime()) {
     return;
   }
@@ -1492,13 +1492,13 @@ async function openLocalFile(path: string) {
   await open(path);
 }
 
-function localFileHref(path: string) {
+export function localFileHref(path: string) {
   const normalizedPath = path.replace(/\\/g, "/");
   const prefix = normalizedPath.startsWith("/") ? "file://" : "file:///";
   return encodeURI(`${prefix}${normalizedPath}`);
 }
 
-async function selectTraceFile(mode: "open" | "save", currentPath: string) {
+export async function selectTraceFile(mode: "open" | "save", currentPath: string) {
   if (!isTauriRuntime()) {
     return null;
   }
@@ -1964,7 +1964,7 @@ function CommandsPage() {
   );
 }
 
-type CommandRunRecord = {
+export type CommandRunRecord = {
   requestId: string;
   person: string;
   command: string;
@@ -2053,7 +2053,7 @@ function CommandLogList({ logs }: { logs: RuntimeLog[] }) {
   );
 }
 
-function buildCommandArgs(
+export function buildCommandArgs(
   option: CommandOption | null,
   values: Record<string, string>,
   rawArgs: string,
@@ -2075,7 +2075,7 @@ function buildCommandArgs(
   return [...args, ...splitCommandLine(rawArgs)];
 }
 
-function splitCommandLine(value: string): string[] {
+export function splitCommandLine(value: string): string[] {
   const args: string[] = [];
   const pattern = /"([^"]*)"|'([^']*)'|(\S+)/g;
   for (const match of value.matchAll(pattern)) {
@@ -2091,7 +2091,7 @@ function requirementLabel(
   return t(`commands.requirements.${kind}`);
 }
 
-function upsertCommandRecord(
+export function upsertCommandRecord(
   records: CommandRunRecord[],
   next: CommandRunRecord,
 ): CommandRunRecord[] {
@@ -2125,7 +2125,7 @@ function stringPayload(value: unknown): string {
   return typeof value === "string" ? value : "";
 }
 
-function commandFailureDetail(event: RuntimeEvent): string {
+export function commandFailureDetail(event: RuntimeEvent): string {
   return JSON.stringify(
     {
       request_id: event.request_id,
@@ -2137,7 +2137,7 @@ function commandFailureDetail(event: RuntimeEvent): string {
   );
 }
 
-function formatCommandEvent(event: RuntimeEvent): string {
+export function formatCommandEvent(event: RuntimeEvent): string {
   const { payload } = event;
   if (typeof payload.message === "string") {
     return payload.message;

--- a/desktop/src/Bootstrap.test.tsx
+++ b/desktop/src/Bootstrap.test.tsx
@@ -1,0 +1,130 @@
+import { MantineProvider } from "@mantine/core";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Bootstrap } from "./Bootstrap";
+import { startBackend } from "./api/backend";
+import i18n from "./i18n";
+import "./i18n";
+
+const t = i18n.getFixedT("en");
+
+vi.mock("./api/backend", () => ({
+  startBackend: vi.fn(async () => undefined),
+}));
+
+vi.mock("./App", () => ({
+  App: () => <div>App Mock Loaded</div>,
+}));
+
+const startBackendMock = vi.mocked(startBackend);
+
+function renderBootstrap() {
+  return render(
+    <MantineProvider>
+      <Bootstrap />
+    </MantineProvider>,
+  );
+}
+
+describe("Bootstrap", () => {
+  beforeEach(() => {
+    startBackendMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("shows the loading indicator while the backend starts", async () => {
+    let resolveStart: () => void = () => {};
+    startBackendMock.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveStart = resolve;
+      }),
+    );
+
+    renderBootstrap();
+
+    expect(screen.getByText(t("app.loading.title"))).toBeInTheDocument();
+    expect(screen.getByText(t("app.loading.body"))).toBeInTheDocument();
+    expect(screen.queryByText("App Mock Loaded")).not.toBeInTheDocument();
+
+    resolveStart();
+    await screen.findByText("App Mock Loaded");
+  });
+
+  it("renders the App when startBackend resolves", async () => {
+    startBackendMock.mockResolvedValue(undefined);
+
+    renderBootstrap();
+
+    expect(await screen.findByText("App Mock Loaded")).toBeInTheDocument();
+    expect(screen.queryByText(t("app.loading.title"))).not.toBeInTheDocument();
+  });
+
+  it("shows an error alert with a retry button when startBackend fails", async () => {
+    startBackendMock.mockRejectedValue(new Error("backend exploded"));
+
+    renderBootstrap();
+
+    expect(await screen.findByText(t("app.loading.failed"))).toBeInTheDocument();
+    expect(screen.getByText(/backend exploded/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: t("app.loading.retry") })).toBeInTheDocument();
+    expect(screen.queryByText("App Mock Loaded")).not.toBeInTheDocument();
+  });
+
+  it("returns to loading on retry and can then succeed", async () => {
+    const user = userEvent.setup();
+    startBackendMock.mockRejectedValueOnce(new Error("first failure"));
+
+    renderBootstrap();
+
+    const retry = await screen.findByRole("button", { name: t("app.loading.retry") });
+
+    let resolveRetry: () => void = () => {};
+    startBackendMock.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        resolveRetry = resolve;
+      }),
+    );
+
+    await user.click(retry);
+
+    expect(await screen.findByText(t("app.loading.title"))).toBeInTheDocument();
+    expect(screen.queryByText(t("app.loading.failed"))).not.toBeInTheDocument();
+
+    resolveRetry();
+
+    expect(await screen.findByText("App Mock Loaded")).toBeInTheDocument();
+  });
+
+  it("does not update state after unmount when startBackend resolves late", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    let resolveStart: () => void = () => {};
+    startBackendMock.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveStart = resolve;
+      }),
+    );
+
+    const { unmount } = renderBootstrap();
+    expect(screen.getByText(t("app.loading.title"))).toBeInTheDocument();
+
+    unmount();
+    resolveStart();
+
+    // Allow the resolved promise microtask + any scheduled work to flush.
+    await waitFor(() => {
+      expect(startBackendMock).toHaveBeenCalledTimes(1);
+    });
+
+    expect(
+      errorSpy.mock.calls.some((call) =>
+        String(call[0]).includes("state update on an unmounted component"),
+      ),
+    ).toBe(false);
+    errorSpy.mockRestore();
+  });
+});

--- a/desktop/src/Commands.test.tsx
+++ b/desktop/src/Commands.test.tsx
@@ -1,0 +1,389 @@
+import { MantineProvider, createTheme } from "@mantine/core";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { App } from "./App";
+import {
+  getCommandOptions,
+  getConfigStatus,
+  getTeam,
+  runCommand,
+  subscribeEvents,
+  subscribeLogs,
+  type CommandOption,
+  type ConfigStatus,
+  type RuntimeEvent,
+  type RuntimeLog,
+} from "./api/client";
+import i18n from "./i18n";
+import "./i18n";
+
+const t = i18n.getFixedT("en");
+
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = vi.fn();
+}
+
+vi.mock("@tauri-apps/plugin-shell", () => ({ open: vi.fn() }));
+vi.mock("@tauri-apps/plugin-dialog", () => ({ open: vi.fn(), save: vi.fn() }));
+vi.mock("./setup/SetupPage", () => ({ SetupPage: () => <div>Setup Mock</div> }));
+
+let eventListener: ((event: RuntimeEvent) => void) | null = null;
+let logListener: ((log: RuntimeLog) => void) | null = null;
+
+vi.mock("./api/client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./api/client")>();
+  return {
+    ...actual,
+    getConfigStatus: vi.fn(),
+    getTeam: vi.fn(),
+    getCommandOptions: vi.fn(),
+    getPromptTrace: vi.fn(async () => promptTrace()),
+    runCommand: vi.fn(),
+    subscribeEvents: vi.fn(),
+    subscribeLogs: vi.fn(),
+  };
+});
+
+const getConfigStatusMock = vi.mocked(getConfigStatus);
+const getTeamMock = vi.mocked(getTeam);
+const getCommandOptionsMock = vi.mocked(getCommandOptions);
+const runCommandMock = vi.mocked(runCommand);
+const subscribeEventsMock = vi.mocked(subscribeEvents);
+const subscribeLogsMock = vi.mocked(subscribeLogs);
+
+beforeEach(() => {
+  eventListener = null;
+  logListener = null;
+  getConfigStatusMock.mockReset().mockResolvedValue(configStatus());
+  getTeamMock.mockReset().mockResolvedValue(team());
+  getCommandOptionsMock.mockReset().mockResolvedValue({ options: [catalogCommand()] });
+  runCommandMock.mockReset().mockResolvedValue({ request_id: "req-1", output: "hello output" });
+  subscribeEventsMock.mockReset().mockImplementation((listener) => {
+    eventListener = listener;
+    return () => {
+      eventListener = null;
+    };
+  });
+  subscribeLogsMock.mockReset().mockImplementation((listener) => {
+    logListener = listener;
+    return () => {
+      logListener = null;
+    };
+  });
+});
+
+describe("Commands screen", () => {
+  it("shows the no-active-member blocked alert and disables run", async () => {
+    getTeamMock.mockResolvedValue(team({ members: [member({ is_active: false })] }));
+    renderCommands();
+    await screen.findByRole("heading", { name: t("commands.title") });
+
+    expect(await screen.findByText(t("commands.noMembersTitle"))).toBeInTheDocument();
+    expect(screen.getByText(t("commands.noMembersBody"))).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: t("commands.run") })).toBeDisabled();
+  });
+
+  it("renders an argument form for the selected catalog command", async () => {
+    renderCommands();
+    await screen.findByRole("heading", { name: t("commands.title") });
+
+    expect(await screen.findByRole("textbox", { name: "topic *" })).toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: "mode" })).toBeInTheDocument();
+  });
+
+  it("builds the runCommand payload from positional and keyword inputs", async () => {
+    const user = userEvent.setup();
+    renderCommands();
+    await screen.findByRole("heading", { name: t("commands.title") });
+
+    await user.type(await screen.findByRole("textbox", { name: "topic *" }), " release ");
+    await user.type(screen.getByRole("textbox", { name: "mode" }), "fast");
+    await user.click(screen.getByRole("button", { name: t("commands.run") }));
+
+    await waitFor(() => expect(runCommandMock).toHaveBeenCalledTimes(1));
+    expect(runCommandMock.mock.calls[0][0]).toMatchObject({
+      command: "workflows/sample",
+      args: ["release", "mode=fast"],
+      person: "alice",
+    });
+  });
+
+  it("puts the selected member into the person field", async () => {
+    const user = userEvent.setup();
+    getTeamMock.mockResolvedValue(
+      team({
+        members: [member(), member({ person_id: "bob", name: "Bob" })],
+      }),
+    );
+    renderCommands();
+    await screen.findByRole("heading", { name: t("commands.title") });
+
+    await user.click(await screen.findByRole("textbox", { name: t("commands.member") }));
+    await user.click(await screen.findByText("Bob (bob)"));
+    await user.click(screen.getByRole("button", { name: t("commands.run") }));
+
+    await waitFor(() => expect(runCommandMock).toHaveBeenCalledTimes(1));
+    expect(runCommandMock.mock.calls[0][0]).toMatchObject({ person: "bob" });
+  });
+
+  it("sends raw args in custom-command mode", async () => {
+    const user = userEvent.setup();
+    renderCommands();
+    await screen.findByRole("heading", { name: t("commands.title") });
+    await screen.findByRole("textbox", { name: "topic *" });
+
+    await user.click(screen.getByRole("radio", { name: t("commands.modeCustom") }));
+    await user.type(
+      screen.getByRole("textbox", { name: t("commands.command") }),
+      "scripts/custom.sh",
+    );
+    await user.type(
+      screen.getByRole("textbox", { name: t("commands.rawArgs") }),
+      'a "b c" key=value',
+    );
+    await user.click(screen.getByRole("button", { name: t("commands.run") }));
+
+    await waitFor(() => expect(runCommandMock).toHaveBeenCalledTimes(1));
+    expect(runCommandMock.mock.calls[0][0]).toMatchObject({
+      command: "scripts/custom.sh",
+      args: ["a", "b c", "key=value"],
+    });
+  });
+
+  it("includes the cwd advanced input in the payload", async () => {
+    const user = userEvent.setup();
+    getCommandOptionsMock.mockResolvedValue({
+      options: [catalogCommand({ arguments: [] })],
+    });
+    renderCommands();
+    await screen.findByRole("heading", { name: t("commands.title") });
+
+    await user.click(await screen.findByRole("switch", { name: t("commands.advanced") }));
+    await user.type(screen.getByRole("textbox", { name: t("commands.cwd") }), "/tmp/run-here");
+    await user.click(screen.getByRole("button", { name: t("commands.run") }));
+
+    await waitFor(() => expect(runCommandMock).toHaveBeenCalledTimes(1));
+    expect(runCommandMock.mock.calls[0][0]).toMatchObject({ cwd: "/tmp/run-here" });
+  });
+
+  it("disables run and shows the blocked alert when requirements are unsatisfied", async () => {
+    getCommandOptionsMock.mockResolvedValue({
+      options: [
+        catalogCommand({
+          requirements: [{ kind: "github", satisfied: false, message: "missing" }],
+        }),
+      ],
+    });
+    renderCommands();
+    await screen.findByRole("heading", { name: t("commands.title") });
+
+    expect(await screen.findByText(t("commands.requirementsBlockedTitle"))).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: t("commands.run") })).toBeDisabled();
+    expect(runCommandMock).not.toHaveBeenCalled();
+  });
+
+  it("updates history on command.started, command.finished, and command.failed events", async () => {
+    renderCommands();
+    await screen.findByRole("heading", { name: t("commands.title") });
+    await waitFor(() => expect(eventListener).not.toBeNull());
+
+    await act(() =>
+      eventListener?.({
+        type: "command.started",
+        request_id: "evt-1",
+        payload: { command: "workflows/sample", person: "alice" },
+        timestamp: "2026-06-04T01:00:00Z",
+      }),
+    );
+    expect(await screen.findByText(t("commands.status.running"))).toBeInTheDocument();
+
+    await act(() =>
+      eventListener?.({
+        type: "command.finished",
+        request_id: "evt-1",
+        payload: { command: "workflows/sample", person: "alice" },
+        timestamp: "2026-06-04T01:00:01Z",
+      }),
+    );
+    expect(await screen.findByText(t("commands.status.success"))).toBeInTheDocument();
+
+    await act(() =>
+      eventListener?.({
+        type: "command.failed",
+        request_id: "evt-1",
+        payload: { command: "workflows/sample", person: "alice", code: "boom" },
+        timestamp: "2026-06-04T01:00:02Z",
+      }),
+    );
+    expect(await screen.findByText(t("commands.status.failed"))).toBeInTheDocument();
+  });
+
+  it("ties command logs to the active request id", async () => {
+    renderCommands();
+    await screen.findByRole("heading", { name: t("commands.title") });
+    await waitFor(() => expect(eventListener).not.toBeNull());
+
+    await act(() =>
+      eventListener?.({
+        type: "command.started",
+        request_id: "evt-9",
+        payload: { command: "workflows/sample", person: "alice" },
+        timestamp: "2026-06-04T01:00:00Z",
+      }),
+    );
+    await act(() =>
+      logListener?.({
+        level: "INFO",
+        message: "log for this request",
+        request_id: "evt-9",
+        timestamp: "2026-06-04T01:00:01Z",
+      }),
+    );
+    await act(() =>
+      logListener?.({
+        level: "INFO",
+        message: "log for another request",
+        request_id: "other",
+        timestamp: "2026-06-04T01:00:02Z",
+      }),
+    );
+
+    const user = userEvent.setup();
+    await user.click(await screen.findByRole("tab", { name: t("commands.logs") }));
+
+    expect(await screen.findByText("log for this request")).toBeInTheDocument();
+    expect(screen.queryByText("log for another request")).not.toBeInTheDocument();
+  });
+
+  it("copies the script path via the clipboard outside Tauri", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__;
+    renderCommands();
+    await screen.findByRole("heading", { name: t("commands.title") });
+
+    const scriptLink = await screen.findByRole("link", {
+      name: "/workspace/commands/sample.py",
+    });
+    expect(scriptLink).toHaveAttribute("href", "file:///workspace/commands/sample.py");
+
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+    fireEvent.click(screen.getByRole("button", { name: t("commands.copyScriptPath") }));
+
+    expect(writeText).toHaveBeenCalledWith("/workspace/commands/sample.py");
+  });
+
+  it("opens the script through the Tauri shell instead of following the link", async () => {
+    const shell = await import("@tauri-apps/plugin-shell");
+    const openMock = vi.mocked(shell.open);
+    openMock.mockClear();
+    (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__ = {};
+    const user = userEvent.setup();
+    renderCommands();
+    await screen.findByRole("heading", { name: t("commands.title") });
+
+    await user.click(await screen.findByRole("link", { name: "/workspace/commands/sample.py" }));
+
+    await waitFor(() => expect(openMock).toHaveBeenCalledWith("/workspace/commands/sample.py"));
+    delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__;
+  });
+});
+
+function act(callback: () => void): Promise<void> {
+  return waitFor(() => {
+    callback();
+  });
+}
+
+function renderCommands() {
+  const theme = createTheme({ primaryColor: "dark", defaultRadius: "md" });
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <MantineProvider theme={theme}>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={["/commands"]}>
+          <App />
+        </MemoryRouter>
+      </QueryClientProvider>
+    </MantineProvider>,
+  );
+}
+
+function configStatus(overrides: Partial<ConfigStatus> = {}): ConfigStatus {
+  return {
+    cwd: "/workspace",
+    env_file: "/workspace/.env",
+    env_file_exists: true,
+    primary_config_dir: "/workspace/.guildbotics/config",
+    primary_config_location: "workspace",
+    primary_project_file: "/workspace/.guildbotics/config/project.yml",
+    primary_project_file_exists: true,
+    home_config_dir: "/home/.guildbotics/config",
+    home_project_file: "/home/.guildbotics/config/project.yml",
+    home_project_file_exists: false,
+    active_config_dir: "/workspace/.guildbotics/config",
+    active_config_location: "workspace",
+    storage_dir: "/workspace/.guildbotics",
+    ...overrides,
+  };
+}
+
+type TeamResponse = Awaited<ReturnType<typeof getTeam>>;
+type Member = TeamResponse["members"][number];
+
+function member(overrides: Partial<Member> = {}): Member {
+  return {
+    person_id: "alice",
+    name: "Alice",
+    is_active: true,
+    roles: ["developer"],
+    ...overrides,
+  };
+}
+
+function team(overrides: Partial<TeamResponse> = {}): TeamResponse {
+  return {
+    project: { name: "Demo", language_code: "en", language_name: "English" },
+    members: [member()],
+    ...overrides,
+  };
+}
+
+function catalogCommand(overrides: Partial<CommandOption> = {}): CommandOption {
+  return {
+    command: "workflows/sample",
+    label: "Sample workflow",
+    description: "A sample command",
+    category: "workflow",
+    source: "workspace",
+    path: "/workspace/commands/sample.py",
+    arguments: [
+      { name: "topic", kind: "positional", required: true, default: "" },
+      { name: "mode", kind: "keyword", required: false, default: "" },
+    ],
+    supports_raw_args: true,
+    recommended_input: "",
+    requirements: [],
+    ...overrides,
+  };
+}
+
+function promptTrace() {
+  return {
+    enabled: false,
+    env_file: "",
+    env_file_exists: false,
+    trace_file: "",
+    output_trace_file: "",
+    default_trace_file: "",
+    trace_file_exists: false,
+    event_count: 0,
+    events: [],
+  };
+}

--- a/desktop/src/Diagnostics.test.tsx
+++ b/desktop/src/Diagnostics.test.tsx
@@ -1,0 +1,531 @@
+import { MantineProvider, createTheme } from "@mantine/core";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { App } from "./App";
+import {
+  getConfigStatus,
+  getProjectConfig,
+  getPromptTrace,
+  getTeam,
+  runScenarioDiagnostics,
+  subscribeEvents,
+  subscribeLogs,
+  updatePromptTrace,
+  type ConfigStatus,
+  type DiagnosticCheck,
+  type ProjectConfig,
+  type PromptTraceEntry,
+  type PromptTraceStatus,
+  type RuntimeEvent,
+  type RuntimeLog,
+  type RuntimeStatus,
+  type RuntimeUnitStatus,
+  type ScenarioDiagnosticsResponse,
+  type StreamStatus,
+} from "./api/client";
+import i18n from "./i18n";
+import "./i18n";
+
+const t = i18n.getFixedT("en");
+
+// jsdom lacks scrollIntoView, which Mantine's Combobox calls when opening.
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = vi.fn();
+}
+
+vi.mock("@tauri-apps/plugin-shell", () => ({ open: vi.fn() }));
+vi.mock("@tauri-apps/plugin-dialog", () => ({ open: vi.fn(), save: vi.fn() }));
+vi.mock("./setup/SetupPage", () => ({ SetupPage: () => <div>Setup Mock</div> }));
+
+vi.mock("./api/client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./api/client")>();
+  return {
+    ...actual,
+    getConfigStatus: vi.fn(),
+    getTeam: vi.fn(),
+    getProjectConfig: vi.fn(),
+    getSchedulerStatus: vi.fn(async () => runtimeStatus()),
+    getSchedulerRoutines: vi.fn(async () => ({
+      routines: [{ command: "workflows/ticket_driven_workflow", requires_github: false }],
+    })),
+    getCommandOptions: vi.fn(async () => ({ options: [] })),
+    getPromptTrace: vi.fn(),
+    updatePromptTrace: vi.fn(),
+    verify: vi.fn(),
+    runScenarioDiagnostics: vi.fn(),
+    subscribeEvents: vi.fn(),
+    subscribeLogs: vi.fn(),
+  };
+});
+
+// Drivers captured from the mocked websocket subscriptions, so tests can push
+// events/logs and toggle stream status exactly like the backend would.
+let eventStreams: Array<{
+  onEvent: (event: RuntimeEvent) => void;
+  onStatus?: (status: StreamStatus) => void;
+}>;
+let logStreams: Array<{
+  onLog: (log: RuntimeLog) => void;
+  onStatus?: (status: StreamStatus) => void;
+}>;
+
+beforeEach(() => {
+  eventStreams = [];
+  logStreams = [];
+  vi.mocked(getConfigStatus).mockReset().mockResolvedValue(configStatus());
+  vi.mocked(getTeam)
+    .mockReset()
+    .mockResolvedValue({
+      project: { name: "Demo", language_code: "en", language_name: "English" },
+      members: [
+        { person_id: "alice", name: "Alice", is_active: true, roles: ["developer"] },
+        { person_id: "bob", name: "Bob", is_active: false, roles: ["reviewer"] },
+      ],
+    });
+  vi.mocked(getProjectConfig).mockReset().mockResolvedValue(projectConfig());
+  vi.mocked(getPromptTrace).mockReset().mockResolvedValue(promptTrace());
+  vi.mocked(updatePromptTrace)
+    .mockReset()
+    .mockResolvedValue(promptTrace({ enabled: true, output_trace_file: "/workspace/trace.jsonl" }));
+  vi.mocked(runScenarioDiagnostics).mockReset().mockResolvedValue(scenarioResponse());
+  vi.mocked(subscribeEvents)
+    .mockReset()
+    .mockImplementation((onEvent, onStatus) => {
+      eventStreams.push({ onEvent, onStatus });
+      onStatus?.("connecting");
+      return () => {};
+    });
+  vi.mocked(subscribeLogs)
+    .mockReset()
+    .mockImplementation((onLog, onStatus) => {
+      logStreams.push({ onLog, onStatus });
+      onStatus?.("connecting");
+      return () => {};
+    });
+});
+
+function emitEvent(event: RuntimeEvent) {
+  act(() => {
+    for (const stream of eventStreams) {
+      stream.onEvent(event);
+    }
+  });
+}
+
+function emitLog(log: RuntimeLog) {
+  act(() => {
+    for (const stream of logStreams) {
+      stream.onLog(log);
+    }
+  });
+}
+
+function setEventStreamStatus(status: StreamStatus) {
+  act(() => {
+    for (const stream of eventStreams) {
+      stream.onStatus?.(status);
+    }
+  });
+}
+
+describe("Diagnostics readiness tab", () => {
+  it("renders the config / env / member / github readiness badges", async () => {
+    renderApp();
+    await screen.findByRole("heading", { name: t("diagnostics.title") });
+
+    expect(await screen.findByText(t("overview.ready"))).toBeInTheDocument();
+    expect(screen.getByText(t("overview.found"))).toBeInTheDocument();
+    expect(screen.getByText(t("overview.enabled"))).toBeInTheDocument();
+    // Only the active member is counted.
+    expect(screen.getByText("1")).toBeInTheDocument();
+  });
+
+  it("runs readiness diagnostics and reports an all-ok summary", async () => {
+    const user = userEvent.setup();
+    renderApp();
+    await screen.findByRole("heading", { name: t("diagnostics.title") });
+
+    await user.click(screen.getByRole("button", { name: t("overview.scenarioDiagnostics.run") }));
+
+    await waitFor(() => expect(runScenarioDiagnostics).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText(t("overview.scenarioDiagnostics.ok"))).toBeInTheDocument();
+  });
+
+  it("renders warning and error scenario checks with their messages", async () => {
+    const user = userEvent.setup();
+    vi.mocked(runScenarioDiagnostics).mockResolvedValue(
+      scenarioResponse({
+        ok: false,
+        checks: [
+          diagnosticCheck({ status: "ok", code: "config_load" }),
+          diagnosticCheck({
+            status: "warning",
+            section: "slack",
+            code: "slack_missing",
+            message: "Slack token is not configured",
+          }),
+          diagnosticCheck({
+            status: "error",
+            section: "llm",
+            code: "llm_missing",
+            message: "LLM API key is missing",
+          }),
+        ],
+      }),
+    );
+    renderApp();
+    await screen.findByRole("heading", { name: t("diagnostics.title") });
+
+    await user.click(screen.getByRole("button", { name: t("overview.scenarioDiagnostics.run") }));
+
+    // No localized title/description exists for these codes, so the raw message
+    // appears in both the alert title and body.
+    expect((await screen.findAllByText("Slack token is not configured")).length).toBeGreaterThan(0);
+    expect(screen.getAllByText("LLM API key is missing").length).toBeGreaterThan(0);
+    // The passing check is not surfaced as an issue alert.
+    expect(screen.queryByText(t("overview.scenarioDiagnostics.ok"))).not.toBeInTheDocument();
+  });
+
+  it("shows an alert when scenario diagnostics fail", async () => {
+    const user = userEvent.setup();
+    vi.mocked(runScenarioDiagnostics).mockRejectedValue(new Error("scenario blew up"));
+    renderApp();
+    await screen.findByRole("heading", { name: t("diagnostics.title") });
+
+    await user.click(screen.getByRole("button", { name: t("overview.scenarioDiagnostics.run") }));
+
+    expect(await screen.findByText(t("overview.scenarioDiagnostics.failed"))).toBeInTheDocument();
+    expect(screen.getByText("scenario blew up")).toBeInTheDocument();
+  });
+});
+
+describe("Diagnostics prompt trace tab", () => {
+  it("applies an edited read path and refetches with the new path", async () => {
+    const user = userEvent.setup();
+    renderApp();
+    await openTab(user, t("diagnostics.tabs.promptTrace"));
+
+    const field = await screen.findByLabelText(t("overview.promptTrace.readPath"));
+    await user.clear(field);
+    await user.type(field, "/custom/trace.jsonl");
+    await user.keyboard("{Enter}");
+
+    await waitFor(() =>
+      expect(
+        vi.mocked(getPromptTrace).mock.calls.some((call) => call[1] === "/custom/trace.jsonl"),
+      ).toBe(true),
+    );
+  });
+
+  it("resets the read path back to the default trace file", async () => {
+    const user = userEvent.setup();
+    renderApp();
+    await openTab(user, t("diagnostics.tabs.promptTrace"));
+
+    const field = await screen.findByLabelText(t("overview.promptTrace.readPath"));
+    await waitFor(() => expect(field).toHaveValue("/workspace/.guildbotics/trace.jsonl"));
+    await user.clear(field);
+    await user.type(field, "/other/path.jsonl");
+
+    await user.click(
+      screen.getByRole("button", { name: t("overview.promptTrace.resetDefaultPath") }),
+    );
+
+    // Reset loads the default trace file and refetches the trace list with it.
+    await waitFor(() =>
+      expect(
+        vi
+          .mocked(getPromptTrace)
+          .mock.calls.some((call) => call[1] === "/workspace/.guildbotics/default.jsonl"),
+      ).toBe(true),
+    );
+  });
+
+  // The prompt-trace OUTPUT settings (enable switch + output path) live in the
+  // PromptTraceOutputSettings panel rendered on the Service Runtime page, not on
+  // the Diagnostics prompt-trace tab (which only shows the read path). See the
+  // spec-vs-source note in the session report.
+  it("toggles the runtime output trace on and persists the choice", async () => {
+    const user = userEvent.setup();
+    renderApp("/service");
+    await screen.findByRole("heading", { name: t("service.title") });
+
+    await user.click(
+      await screen.findByRole("switch", { name: t("overview.promptTrace.disabled") }),
+    );
+
+    await waitFor(() => expect(updatePromptTrace).toHaveBeenCalledTimes(1));
+    expect(vi.mocked(updatePromptTrace).mock.calls[0][0]).toMatchObject({ enabled: true });
+  });
+
+  it("updates the output trace path through updatePromptTrace", async () => {
+    const user = userEvent.setup();
+    renderApp("/service");
+    await screen.findByRole("heading", { name: t("service.title") });
+
+    const field = await screen.findByLabelText(t("overview.promptTrace.outputPath"));
+    await user.clear(field);
+    await user.type(field, "/workspace/new-output.jsonl");
+    await user.keyboard("{Enter}");
+
+    await waitFor(() => expect(updatePromptTrace).toHaveBeenCalledTimes(1));
+    expect(vi.mocked(updatePromptTrace).mock.calls[0][0]).toMatchObject({
+      trace_path: "/workspace/new-output.jsonl",
+    });
+  });
+
+  it("opens the trace details drawer when a trace row is selected", async () => {
+    const user = userEvent.setup();
+    vi.mocked(getPromptTrace).mockResolvedValue(
+      promptTrace({
+        event_count: 2,
+        // Trace events arrive newest-first, so the response precedes its request;
+        // buildTraceGroups pairs a response with the earlier-listed request.
+        events: [
+          traceEntry({
+            event: "llm.response",
+            person_id: "alice",
+            brain: "brains/writer.yml",
+            response: "Here is the summary",
+          }),
+          traceEntry({
+            event: "llm.request",
+            person_id: "alice",
+            brain: "brains/writer.yml",
+            prompt: "Write a summary",
+          }),
+        ],
+      }),
+    );
+    renderApp();
+    await openTab(user, t("diagnostics.tabs.promptTrace"));
+
+    const row = await screen.findByRole("button", { name: /writer/ });
+    await user.click(row);
+
+    const dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByText("Write a summary")).toBeInTheDocument();
+    expect(within(dialog).getByText("Here is the summary")).toBeInTheDocument();
+  });
+});
+
+describe("Diagnostics runtime stream tab", () => {
+  it("renders streamed events and switches to the logs view", async () => {
+    const user = userEvent.setup();
+    renderApp();
+    await openTab(user, t("diagnostics.tabs.runtimeStream"));
+
+    emitEvent(runtimeEvent({ type: "scheduler.running" }));
+    expect(
+      await screen.findByText(t("overview.eventSummaries.schedulerRunning")),
+    ).toBeInTheDocument();
+
+    emitLog(runtimeLog({ message: "worker started", level: "INFO" }));
+    // Logs are not shown while the events view is active.
+    expect(screen.queryByText("worker started")).not.toBeInTheDocument();
+
+    // The events/logs view switcher is a SegmentedControl; its "Logs" segment
+    // label is unique on the runtime stream tab.
+    await user.click(screen.getByText(t("overview.logs")));
+    expect(await screen.findByText("worker started")).toBeInTheDocument();
+  });
+
+  it("filters the event feed by the selected category", async () => {
+    const user = userEvent.setup();
+    renderApp();
+    await openTab(user, t("diagnostics.tabs.runtimeStream"));
+
+    emitEvent(runtimeEvent({ type: "command.failed", payload: { message: "boom" } }));
+    emitEvent(runtimeEvent({ type: "scheduler.running" }));
+    expect(await screen.findByText("boom")).toBeInTheDocument();
+
+    await user.click(screen.getByText(t("overview.feedFilters.error")));
+
+    expect(screen.getByText("boom")).toBeInTheDocument();
+    expect(
+      screen.queryByText(t("overview.eventSummaries.schedulerRunning")),
+    ).not.toBeInTheDocument();
+  });
+
+  it("reflects the websocket connection status in the stream badge", async () => {
+    const user = userEvent.setup();
+    renderApp();
+    await openTab(user, t("diagnostics.tabs.runtimeStream"));
+
+    expect(
+      (await screen.findAllByText(t("overview.streamStates.connecting"))).length,
+    ).toBeGreaterThan(0);
+
+    setEventStreamStatus("connected");
+    expect(await screen.findByText(t("overview.streamStates.connected"))).toBeInTheDocument();
+  });
+});
+
+async function openTab(user: ReturnType<typeof userEvent.setup>, name: string) {
+  await screen.findByRole("heading", { name: t("diagnostics.title") });
+  await user.click(screen.getByRole("tab", { name }));
+}
+
+function renderApp(initialPath = "/diagnostics") {
+  const theme = createTheme({ primaryColor: "dark", defaultRadius: "md" });
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <MantineProvider theme={theme}>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[initialPath]}>
+          <App />
+        </MemoryRouter>
+      </QueryClientProvider>
+    </MantineProvider>,
+  );
+}
+
+function configStatus(overrides: Partial<ConfigStatus> = {}): ConfigStatus {
+  return {
+    cwd: "/workspace",
+    env_file: "/workspace/.env",
+    env_file_exists: true,
+    primary_config_dir: "/workspace/.guildbotics/config",
+    primary_config_location: "workspace",
+    primary_project_file: "/workspace/.guildbotics/config/project.yml",
+    primary_project_file_exists: true,
+    home_config_dir: "/home/.guildbotics/config",
+    home_project_file: "/home/.guildbotics/config/project.yml",
+    home_project_file_exists: false,
+    active_config_dir: "/workspace/.guildbotics/config",
+    active_config_location: "workspace",
+    storage_dir: "/workspace/.guildbotics",
+    ...overrides,
+  };
+}
+
+function projectConfig(overrides: Partial<ProjectConfig> = {}): ProjectConfig {
+  return {
+    config_dir: "/workspace/.guildbotics/config",
+    env_file_path: "/workspace/.env",
+    language: "en",
+    description: "Demo project",
+    llm_api_type: "openai",
+    cli_agent: "codex",
+    github_enabled: true,
+    github_project_url: "",
+    github_repository_url: "",
+    repo_base_url: "https://github.com",
+    has_google_api_key: false,
+    has_openai_api_key: true,
+    has_anthropic_api_key: false,
+    ...overrides,
+  };
+}
+
+function promptTrace(overrides: Partial<PromptTraceStatus> = {}): PromptTraceStatus {
+  return {
+    enabled: false,
+    env_file: "/workspace/.env",
+    env_file_exists: true,
+    trace_file: "/workspace/.guildbotics/trace.jsonl",
+    output_trace_file: "/workspace/.guildbotics/trace.jsonl",
+    default_trace_file: "/workspace/.guildbotics/default.jsonl",
+    trace_file_exists: true,
+    event_count: 0,
+    events: [],
+    ...overrides,
+  };
+}
+
+function traceEntry(overrides: Partial<PromptTraceEntry> = {}): PromptTraceEntry {
+  return {
+    event: "llm.request",
+    timestamp: "2026-01-01T00:00:00Z",
+    person_id: "alice",
+    brain: "brains/writer.yml",
+    command: "",
+    target: "",
+    cwd: "",
+    description: "",
+    transcript: "",
+    prompt: "",
+    response: "",
+    error: "",
+    fields: {},
+    ...overrides,
+  };
+}
+
+function scenarioResponse(
+  overrides: Partial<ScenarioDiagnosticsResponse> = {},
+): ScenarioDiagnosticsResponse {
+  const checks = overrides.checks ?? [diagnosticCheck({ status: "ok", code: "config_load" })];
+  return {
+    ok: overrides.ok ?? true,
+    active_members: overrides.active_members ?? ["alice"],
+    checks,
+    warnings: overrides.warnings ?? checks.filter((c) => c.status === "warning"),
+    errors: overrides.errors ?? checks.filter((c) => c.status === "error"),
+  };
+}
+
+function diagnosticCheck(overrides: Partial<DiagnosticCheck> = {}): DiagnosticCheck {
+  return {
+    section: "config",
+    code: "config_load",
+    status: "ok",
+    message: "ok",
+    target: "",
+    person_id: "",
+    context: {},
+    ...overrides,
+  };
+}
+
+function runtimeEvent(overrides: Partial<RuntimeEvent> = {}): RuntimeEvent {
+  return {
+    type: "scheduler.running",
+    request_id: null,
+    payload: {},
+    timestamp: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function runtimeLog(overrides: Partial<RuntimeLog> = {}): RuntimeLog {
+  return {
+    level: "INFO",
+    message: "log line",
+    request_id: null,
+    timestamp: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function runtimeStatus(): RuntimeStatus {
+  return { scheduler: runtimeUnit("scheduler"), events: runtimeUnit("events") };
+}
+
+function runtimeUnit(target: "scheduler" | "events"): RuntimeUnitStatus {
+  return {
+    target,
+    state: "stopped",
+    running: false,
+    started_at: null,
+    stopped_at: null,
+    error: null,
+    routine_commands: [],
+    max_consecutive_errors: null,
+    routine_interval_minutes: null,
+    active_member_count: 1,
+    worker_count: 0,
+    workflow_command: null,
+    subscription_count: 0,
+    listener_count: 0,
+    cycle_count: 0,
+    cycle_failure_count: 0,
+    events_drained_count: 0,
+    events_delivered_count: 0,
+    events_skipped_processed_count: 0,
+  };
+}

--- a/desktop/src/ServiceRuntime.test.tsx
+++ b/desktop/src/ServiceRuntime.test.tsx
@@ -1,0 +1,430 @@
+import { MantineProvider, createTheme } from "@mantine/core";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { App } from "./App";
+import {
+  getConfigStatus,
+  getProjectConfig,
+  getSchedulerRoutines,
+  getSchedulerStatus,
+  getTeam,
+  startScheduler,
+  stopScheduler,
+  type ConfigStatus,
+  type ProjectConfig,
+  type RoutineOption,
+  type RuntimeStatus,
+  type RuntimeUnitStatus,
+} from "./api/client";
+import i18n from "./i18n";
+import "./i18n";
+
+const t = i18n.getFixedT("en");
+
+// jsdom lacks scrollIntoView, which Mantine's Combobox calls when opening a Select.
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = vi.fn();
+}
+
+vi.mock("@tauri-apps/plugin-shell", () => ({ open: vi.fn() }));
+vi.mock("@tauri-apps/plugin-dialog", () => ({ open: vi.fn(), save: vi.fn() }));
+vi.mock("./setup/SetupPage", () => ({ SetupPage: () => <div>Setup Mock</div> }));
+
+vi.mock("./api/client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./api/client")>();
+  return {
+    ...actual,
+    getConfigStatus: vi.fn(),
+    getTeam: vi.fn(),
+    getSchedulerRoutines: vi.fn(),
+    getSchedulerStatus: vi.fn(),
+    getProjectConfig: vi.fn(),
+    getCommandOptions: vi.fn(async () => ({ options: [] })),
+    getPromptTrace: vi.fn(async () => promptTrace()),
+    startScheduler: vi.fn(),
+    stopScheduler: vi.fn(),
+    subscribeEvents: vi.fn(() => () => {}),
+    subscribeLogs: vi.fn(() => () => {}),
+  };
+});
+
+const getConfigStatusMock = vi.mocked(getConfigStatus);
+const getTeamMock = vi.mocked(getTeam);
+const getSchedulerRoutinesMock = vi.mocked(getSchedulerRoutines);
+const getSchedulerStatusMock = vi.mocked(getSchedulerStatus);
+const getProjectConfigMock = vi.mocked(getProjectConfig);
+const startSchedulerMock = vi.mocked(startScheduler);
+const stopSchedulerMock = vi.mocked(stopScheduler);
+
+beforeEach(() => {
+  getConfigStatusMock.mockReset().mockResolvedValue(configStatus());
+  getTeamMock.mockReset().mockResolvedValue({
+    project: { name: "Demo", language_code: "en", language_name: "English" },
+    members: [{ person_id: "alice", name: "Alice", is_active: true, roles: ["developer"] }],
+  });
+  getSchedulerRoutinesMock.mockReset().mockResolvedValue({ routines: [routine()] });
+  getSchedulerStatusMock.mockReset().mockResolvedValue(runtimeStatus());
+  getProjectConfigMock.mockReset().mockResolvedValue(projectConfig());
+  startSchedulerMock.mockReset().mockResolvedValue(runtimeStatus());
+  stopSchedulerMock.mockReset().mockResolvedValue(runtimeStatus());
+});
+
+describe("Service Runtime screen", () => {
+  it("sends only=scheduler when only the scheduler target is enabled", async () => {
+    const user = userEvent.setup();
+    renderApp("/service");
+    await screen.findByRole("heading", { name: t("service.title") });
+
+    await user.click(eventsSwitch());
+    await user.click(screen.getByRole("button", { name: t("overview.start") }));
+
+    await waitFor(() => expect(startSchedulerMock).toHaveBeenCalledTimes(1));
+    expect(startSchedulerMock.mock.calls[0][0]).toMatchObject({ only: "scheduler" });
+  });
+
+  it("includes the selected routine in routine_commands when scheduler is enabled", async () => {
+    const user = userEvent.setup();
+    renderApp("/service");
+    await screen.findByRole("heading", { name: t("service.title") });
+
+    await user.click(screen.getByRole("button", { name: t("overview.start") }));
+
+    await waitFor(() => expect(startSchedulerMock).toHaveBeenCalledTimes(1));
+    expect(startSchedulerMock.mock.calls[0][0]).toMatchObject({
+      routine_commands: ["workflows/ticket_driven_workflow"],
+    });
+  });
+
+  it("omits routine_commands and sends only=events when events-only is selected", async () => {
+    const user = userEvent.setup();
+    renderApp("/service");
+    await screen.findByRole("heading", { name: t("service.title") });
+
+    await user.click(schedulerSwitch());
+    await user.click(screen.getByRole("button", { name: t("overview.start") }));
+
+    await waitFor(() => expect(startSchedulerMock).toHaveBeenCalledTimes(1));
+    const body = startSchedulerMock.mock.calls[0][0];
+    expect(body).toMatchObject({ only: "events" });
+    expect(body).not.toHaveProperty("routine_commands");
+  });
+
+  it("disables start when both targets are disabled", async () => {
+    const user = userEvent.setup();
+    renderApp("/service");
+    await screen.findByRole("heading", { name: t("service.title") });
+
+    await user.click(schedulerSwitch());
+    await user.click(eventsSwitch());
+
+    expect(screen.getByRole("button", { name: t("overview.start") })).toBeDisabled();
+    expect(screen.getByText(t("service.noTargetTitle"))).toBeInTheDocument();
+  });
+
+  it("disables start and shows a setup link when project config is missing", async () => {
+    getConfigStatusMock.mockResolvedValue(
+      configStatus({ primary_project_file_exists: false, home_project_file_exists: false }),
+    );
+    renderApp("/service");
+    await screen.findByRole("heading", { name: t("service.title") });
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: t("overview.start") })).toBeDisabled(),
+    );
+    expect(screen.getByText(t("overview.setupRequiredTitle"))).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: t("overview.openSetup") })).toHaveAttribute(
+      "href",
+      "/setup",
+    );
+  });
+
+  it("reflects routine interval and max consecutive errors in the start payload", async () => {
+    const user = userEvent.setup();
+    renderApp("/service");
+    await screen.findByRole("heading", { name: t("service.title") });
+
+    const interval = screen.getByRole("textbox", { name: t("overview.routineIntervalMinutes") });
+    await user.clear(interval);
+    await user.type(interval, "30");
+    const maxErrors = screen.getByRole("textbox", { name: t("overview.maxConsecutiveErrors") });
+    await user.clear(maxErrors);
+    await user.type(maxErrors, "7");
+
+    await user.click(screen.getByRole("button", { name: t("overview.start") }));
+
+    await waitFor(() => expect(startSchedulerMock).toHaveBeenCalledTimes(1));
+    expect(startSchedulerMock.mock.calls[0][0]).toMatchObject({
+      routine_interval_minutes: 30,
+      max_consecutive_errors: 7,
+    });
+  });
+
+  it("blocks start when the selected routine requires GitHub but GitHub is disabled", async () => {
+    getSchedulerRoutinesMock.mockResolvedValue({
+      routines: [routine({ command: "workflows/github_flow", requires_github: true })],
+    });
+    getProjectConfigMock.mockResolvedValue(projectConfig({ github_enabled: false }));
+    renderApp("/service");
+    await screen.findByRole("heading", { name: t("service.title") });
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: t("overview.start") })).toBeDisabled(),
+    );
+    expect(screen.getByText(t("overview.startGuardTitle"))).toBeInTheDocument();
+    expect(startSchedulerMock).not.toHaveBeenCalled();
+  });
+
+  it("renders the running state and offers a stop action", async () => {
+    getSchedulerStatusMock.mockResolvedValue(
+      runtimeStatus({
+        scheduler: runtimeUnit("scheduler", { state: "running", running: true }),
+      }),
+    );
+    renderApp("/service");
+    await screen.findByRole("heading", { name: t("service.title") });
+
+    await screen.findByRole("button", { name: t("overview.stop") });
+    expect(screen.getAllByText(t("overview.runtimeStates.running")).length).toBeGreaterThan(0);
+  });
+
+  it("renders the failed state with the runtime error message", async () => {
+    getSchedulerStatusMock.mockResolvedValue(
+      runtimeStatus({
+        scheduler: runtimeUnit("scheduler", { state: "failed", error: "worker crashed" }),
+      }),
+    );
+    renderApp("/service");
+    await screen.findByRole("heading", { name: t("service.title") });
+
+    expect(await screen.findByText(t("overview.runtimeStates.failed"))).toBeInTheDocument();
+    expect(screen.getByText("worker crashed")).toBeInTheDocument();
+  });
+
+  it("shows the stop-timeout pending warning instead of an error", async () => {
+    getSchedulerStatusMock.mockResolvedValue(
+      runtimeStatus({
+        scheduler: runtimeUnit("scheduler", {
+          state: "failed",
+          running: true,
+          error: "worker did not stop before timeout",
+        }),
+      }),
+    );
+    renderApp("/service");
+    await screen.findByRole("heading", { name: t("service.title") });
+
+    expect(await screen.findByText(t("overview.stopDelayHint"))).toBeInTheDocument();
+    expect(screen.getAllByText(t("overview.runtimeStates.stopping")).length).toBeGreaterThan(0);
+  });
+
+  it("shows an alert when the start mutation fails", async () => {
+    const user = userEvent.setup();
+    startSchedulerMock.mockRejectedValue(new Error("start blew up"));
+    renderApp("/service");
+    await screen.findByRole("heading", { name: t("service.title") });
+
+    await user.click(screen.getByRole("button", { name: t("overview.start") }));
+
+    expect(await screen.findByText(t("overview.startError"))).toBeInTheDocument();
+    expect(screen.getByText("start blew up")).toBeInTheDocument();
+  });
+
+  it("shows an alert when the stop mutation fails", async () => {
+    const user = userEvent.setup();
+    stopSchedulerMock.mockRejectedValue(new Error("stop blew up"));
+    getSchedulerStatusMock.mockResolvedValue(
+      runtimeStatus({
+        scheduler: runtimeUnit("scheduler", { state: "running", running: true }),
+      }),
+    );
+    renderApp("/service");
+    await screen.findByRole("heading", { name: t("service.title") });
+
+    await user.click(await screen.findByRole("button", { name: t("overview.stop") }));
+
+    expect(await screen.findByText(t("overview.stopError"))).toBeInTheDocument();
+    expect(screen.getByText("stop blew up")).toBeInTheDocument();
+  });
+});
+
+describe("App routing and layout", () => {
+  it("redirects to /setup when the project config is missing", async () => {
+    getConfigStatusMock.mockResolvedValue(
+      configStatus({ primary_project_file_exists: false, home_project_file_exists: false }),
+    );
+    renderApp("/");
+
+    expect(await screen.findByText("Setup Mock")).toBeInTheDocument();
+  });
+
+  it("redirects to /service when the project config exists", async () => {
+    renderApp("/");
+
+    expect(await screen.findByRole("heading", { name: t("service.title") })).toBeInTheDocument();
+  });
+
+  it("redirects /overview to /service", async () => {
+    renderApp("/overview");
+
+    expect(await screen.findByRole("heading", { name: t("service.title") })).toBeInTheDocument();
+  });
+
+  it("marks the active nav item based on the current route", async () => {
+    renderApp("/service");
+    await screen.findByRole("heading", { name: t("service.title") });
+
+    const serviceLink = screen.getByRole("link", { name: new RegExp(t("app.nav.service")) });
+    expect(serviceLink).toHaveClass("active");
+    const setupLink = screen.getByRole("link", { name: new RegExp(t("app.nav.setup")) });
+    expect(setupLink).not.toHaveClass("active");
+  });
+
+  it("calls setAppLanguage when the language select changes", async () => {
+    const user = userEvent.setup();
+    const changeSpy = vi.spyOn(i18n, "changeLanguage");
+    renderApp("/service");
+    await screen.findByRole("heading", { name: t("service.title") });
+
+    await user.click(screen.getByRole("textbox", { name: t("app.language.label") }));
+    await user.click(await screen.findByText(t("app.language.japanese")));
+
+    await waitFor(() => expect(changeSpy).toHaveBeenCalledWith("ja"));
+    changeSpy.mockRestore();
+    await i18n.changeLanguage("en");
+  });
+});
+
+function renderApp(initialPath: string) {
+  const theme = createTheme({ primaryColor: "dark", defaultRadius: "md" });
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <MantineProvider theme={theme}>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[initialPath]}>
+          <App />
+        </MemoryRouter>
+      </QueryClientProvider>
+    </MantineProvider>,
+  );
+}
+
+function schedulerSwitch() {
+  return within(panelFor(t("overview.schedulerCard.title"))).getByRole("switch", {
+    name: t("service.startTarget"),
+  });
+}
+
+function eventsSwitch() {
+  return within(panelFor(t("overview.eventsCard.title"))).getByRole("switch", {
+    name: t("service.startTarget"),
+  });
+}
+
+function panelFor(title: string): HTMLElement {
+  const heading = screen.getByText(title);
+  const panel = heading.closest(".service-unit-panel");
+  if (!(panel instanceof HTMLElement)) {
+    throw new Error(`Unable to find service unit panel for ${title}`);
+  }
+  return panel;
+}
+
+function configStatus(overrides: Partial<ConfigStatus> = {}): ConfigStatus {
+  return {
+    cwd: "/workspace",
+    env_file: "/workspace/.env",
+    env_file_exists: true,
+    primary_config_dir: "/workspace/.guildbotics/config",
+    primary_config_location: "workspace",
+    primary_project_file: "/workspace/.guildbotics/config/project.yml",
+    primary_project_file_exists: true,
+    home_config_dir: "/home/.guildbotics/config",
+    home_project_file: "/home/.guildbotics/config/project.yml",
+    home_project_file_exists: false,
+    active_config_dir: "/workspace/.guildbotics/config",
+    active_config_location: "workspace",
+    storage_dir: "/workspace/.guildbotics",
+    ...overrides,
+  };
+}
+
+function projectConfig(overrides: Partial<ProjectConfig> = {}): ProjectConfig {
+  return {
+    config_dir: "/workspace/.guildbotics/config",
+    env_file_path: "/workspace/.env",
+    language: "en",
+    description: "Demo project",
+    llm_api_type: "openai",
+    cli_agent: "codex",
+    github_enabled: false,
+    github_project_url: "",
+    github_repository_url: "",
+    repo_base_url: "https://github.com",
+    has_google_api_key: false,
+    has_openai_api_key: true,
+    has_anthropic_api_key: false,
+    ...overrides,
+  };
+}
+
+function routine(overrides: Partial<RoutineOption> = {}): RoutineOption {
+  return {
+    command: "workflows/ticket_driven_workflow",
+    requires_github: false,
+    ...overrides,
+  };
+}
+
+function runtimeStatus(overrides: Partial<RuntimeStatus> = {}): RuntimeStatus {
+  return {
+    scheduler: runtimeUnit("scheduler"),
+    events: runtimeUnit("events"),
+    ...overrides,
+  };
+}
+
+function runtimeUnit(
+  target: "scheduler" | "events",
+  overrides: Partial<RuntimeUnitStatus> = {},
+): RuntimeUnitStatus {
+  return {
+    target,
+    state: "stopped",
+    running: false,
+    started_at: null,
+    stopped_at: null,
+    error: null,
+    routine_commands: [],
+    max_consecutive_errors: null,
+    routine_interval_minutes: null,
+    active_member_count: 1,
+    worker_count: 0,
+    workflow_command: null,
+    subscription_count: 0,
+    listener_count: 0,
+    cycle_count: 0,
+    cycle_failure_count: 0,
+    events_drained_count: 0,
+    events_delivered_count: 0,
+    events_skipped_processed_count: 0,
+    ...overrides,
+  };
+}
+
+function promptTrace() {
+  return {
+    enabled: false,
+    env_file: "",
+    env_file_exists: false,
+    trace_file: "",
+    output_trace_file: "",
+    default_trace_file: "",
+    trace_file_exists: false,
+    event_count: 0,
+    events: [],
+  };
+}

--- a/desktop/src/api/backend.test.ts
+++ b/desktop/src/api/backend.test.ts
@@ -1,0 +1,249 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// backend.ts reads `import.meta.env` and `localStorage` at module-evaluation
+// time, so every test resets the module registry and re-imports it freshly.
+
+const configureApi = vi.fn();
+const setWorkspace = vi.fn(async () => ({}));
+let apiBase = "http://127.0.0.1:8765";
+const getApiBase = vi.fn(() => apiBase);
+
+vi.mock("./client", () => ({
+  configureApi,
+  getApiBase,
+  setWorkspace,
+}));
+
+const invoke = vi.fn();
+vi.mock("@tauri-apps/api/core", () => ({ invoke }));
+
+type BackendModule = typeof import("./backend");
+
+async function loadBackend(): Promise<BackendModule> {
+  vi.resetModules();
+  return import("./backend");
+}
+
+function setApiBase(base: string) {
+  apiBase = base;
+}
+
+type FetchMock = (url: string, init: RequestInit) => Promise<Response>;
+
+function okResponse(): Response {
+  return { ok: true, text: async () => "ok" } as unknown as Response;
+}
+
+function failResponse(status: number, body: string): Response {
+  return { ok: false, status, text: async () => body } as unknown as Response;
+}
+
+function setTauriRuntime(enabled: boolean) {
+  if (enabled) {
+    (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__ = {};
+  } else {
+    delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__;
+  }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  configureApi.mockReset();
+  setWorkspace.mockReset();
+  setWorkspace.mockResolvedValue({});
+  getApiBase.mockClear();
+  invoke.mockReset();
+  apiBase = "http://127.0.0.1:8765";
+  localStorage.clear();
+  setTauriRuntime(false);
+  vi.unstubAllEnvs();
+});
+
+afterEach(() => {
+  vi.runOnlyPendingTimers();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+  setTauriRuntime(false);
+});
+
+describe("startBackend - browser preview mode", () => {
+  it("configures the API and health-checks without invoking Tauri", async () => {
+    vi.stubEnv("VITE_GUILDBOTICS_API_TOKEN", "preview-token");
+    vi.stubEnv("VITE_GUILDBOTICS_API_BASE", "http://preview.test:9000");
+    setApiBase("http://preview.test:9000");
+    const fetchMock = vi.fn<FetchMock>(async () => okResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    const backend = await loadBackend();
+    await backend.startBackend();
+
+    expect(configureApi).toHaveBeenCalledWith("preview-token", "http://preview.test:9000");
+    expect(invoke).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("http://preview.test:9000/health");
+    expect((init.headers as Record<string, string>)["X-GuildBotics-Session-Token"]).toBe(
+      "preview-token",
+    );
+  });
+});
+
+describe("startBackend - Tauri runtime", () => {
+  it("uses the port and token returned by backend_info", async () => {
+    vi.stubEnv("VITE_GUILDBOTICS_API_TOKEN", "");
+    setTauriRuntime(true);
+    invoke.mockResolvedValue({ port: 7777, token: "runtime-token" });
+    const fetchMock = vi.fn<FetchMock>(async () => {
+      setApiBase("http://127.0.0.1:7777");
+      return okResponse();
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    // getApiBase returns whatever configureApi would have set.
+    setApiBase("http://127.0.0.1:7777");
+
+    const backend = await loadBackend();
+    await backend.startBackend();
+
+    expect(invoke).toHaveBeenCalledWith("backend_info");
+    expect(configureApi).toHaveBeenCalledWith("runtime-token", "http://127.0.0.1:7777");
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("http://127.0.0.1:7777/health");
+    expect((init.headers as Record<string, string>)["X-GuildBotics-Session-Token"]).toBe(
+      "runtime-token",
+    );
+  });
+
+  it("throws a clear error when neither Tauri nor a static token is available", async () => {
+    vi.stubEnv("VITE_GUILDBOTICS_API_TOKEN", "");
+    setTauriRuntime(false);
+
+    const backend = await loadBackend();
+    await expect(backend.startBackend()).rejects.toThrow(
+      "GuildBotics backend is not configured for browser preview.",
+    );
+    expect(invoke).not.toHaveBeenCalled();
+    expect(configureApi).not.toHaveBeenCalled();
+  });
+});
+
+describe("waitForHealth", () => {
+  it("retries past transient fetch failures then succeeds", async () => {
+    vi.stubEnv("VITE_GUILDBOTICS_API_TOKEN", "preview-token");
+    vi.stubEnv("VITE_GUILDBOTICS_API_BASE", "http://preview.test:9000");
+    setApiBase("http://preview.test:9000");
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("ECONNREFUSED"))
+      .mockResolvedValueOnce(failResponse(503, "starting"))
+      .mockResolvedValueOnce(okResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    const backend = await loadBackend();
+    const started = backend.startBackend();
+    // Drain the two 300ms retry backoffs plus the awaited microtasks.
+    await vi.advanceTimersByTimeAsync(700);
+    await started;
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("fails past the deadline including the last error", async () => {
+    vi.stubEnv("VITE_GUILDBOTICS_API_TOKEN", "preview-token");
+    vi.stubEnv("VITE_GUILDBOTICS_API_BASE", "http://preview.test:9000");
+    setApiBase("http://preview.test:9000");
+    const fetchMock = vi.fn(async () => failResponse(500, "still booting"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const backend = await loadBackend();
+    const started = backend.startBackend();
+    const assertion = expect(started).rejects.toThrow(
+      "GuildBotics backend did not start: still booting",
+    );
+    // Advance well past the 45s deadline so the retry loop exits.
+    await vi.advanceTimersByTimeAsync(46_000);
+    await assertion;
+    expect(fetchMock.mock.calls.length).toBeGreaterThan(1);
+  });
+});
+
+describe("restartBackend", () => {
+  it("updates localStorage and the backend workspace", async () => {
+    const backend = await loadBackend();
+    await backend.restartBackend("/projects/demo");
+
+    expect(localStorage.getItem("guildbotics.workspace")).toBe("/projects/demo");
+    expect(setWorkspace).toHaveBeenCalledWith({ workspace_dir: "/projects/demo" });
+  });
+
+  it("clears guildbotics.workspace when setWorkspace fails", async () => {
+    localStorage.setItem("guildbotics.workspace", "/old");
+    setWorkspace.mockRejectedValueOnce(new Error("boom"));
+
+    const backend = await loadBackend();
+    await expect(backend.restartBackend("/projects/demo")).rejects.toThrow("boom");
+
+    expect(localStorage.getItem("guildbotics.workspace")).toBeNull();
+  });
+});
+
+describe("restoreWorkspace via startBackend", () => {
+  it("applies a previously stored workspace on startup", async () => {
+    localStorage.setItem("guildbotics.workspace", "/restored");
+    vi.stubEnv("VITE_GUILDBOTICS_API_TOKEN", "preview-token");
+    vi.stubEnv("VITE_GUILDBOTICS_API_BASE", "http://preview.test:9000");
+    setApiBase("http://preview.test:9000");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => okResponse()),
+    );
+
+    const backend = await loadBackend();
+    await backend.startBackend();
+
+    expect(setWorkspace).toHaveBeenCalledWith({ workspace_dir: "/restored" });
+  });
+
+  it("cleans localStorage on restore failure without breaking startup", async () => {
+    localStorage.setItem("guildbotics.workspace", "/restored");
+    vi.stubEnv("VITE_GUILDBOTICS_API_TOKEN", "preview-token");
+    vi.stubEnv("VITE_GUILDBOTICS_API_BASE", "http://preview.test:9000");
+    setApiBase("http://preview.test:9000");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => okResponse()),
+    );
+    setWorkspace.mockRejectedValueOnce(new Error("restore failed"));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const backend = await loadBackend();
+    // startBackend must resolve even though workspace restore failed.
+    await expect(backend.startBackend()).resolves.toBeUndefined();
+
+    expect(localStorage.getItem("guildbotics.workspace")).toBeNull();
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it("does nothing when no workspace is stored", async () => {
+    vi.stubEnv("VITE_GUILDBOTICS_API_TOKEN", "preview-token");
+    vi.stubEnv("VITE_GUILDBOTICS_API_BASE", "http://preview.test:9000");
+    setApiBase("http://preview.test:9000");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => okResponse()),
+    );
+
+    const backend = await loadBackend();
+    await backend.startBackend();
+
+    expect(setWorkspace).not.toHaveBeenCalled();
+  });
+});
+
+describe("stopBackend", () => {
+  it("resolves without side effects", async () => {
+    const backend = await loadBackend();
+    await expect(backend.stopBackend()).resolves.toBeUndefined();
+    expect(setWorkspace).not.toHaveBeenCalled();
+  });
+});

--- a/desktop/src/api/client.test.ts
+++ b/desktop/src/api/client.test.ts
@@ -1,0 +1,376 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  ApiRequestError,
+  configureApi,
+  getApiBase,
+  getCommandOptions,
+  getConfigStatus,
+  getIntelligenceConfig,
+  getMemberConfig,
+  getPromptTrace,
+  runScenarioDiagnostics,
+  setWorkspace,
+  subscribeEvents,
+  subscribeLogs,
+  verify,
+  type RuntimeEvent,
+  type RuntimeLog,
+  type StreamStatus,
+} from "./client";
+
+type FetchArgs = { url: string; init: RequestInit };
+
+function jsonResponse(body: unknown, init?: { ok?: boolean; status?: number }): Response {
+  return {
+    ok: init?.ok ?? true,
+    status: init?.status ?? 200,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+function captureFetch(response: Response): { calls: FetchArgs[]; mock: ReturnType<typeof vi.fn> } {
+  const calls: FetchArgs[] = [];
+  const mock = vi.fn(async (url: string, init: RequestInit) => {
+    calls.push({ url, init });
+    return response;
+  });
+  vi.stubGlobal("fetch", mock);
+  return { calls, mock };
+}
+
+function headerValue(init: RequestInit, name: string): string | undefined {
+  return (init.headers as Record<string, string>)[name];
+}
+
+const ORIGINAL_BASE = getApiBase();
+
+beforeEach(() => {
+  // Reset module state to a known token + base for deterministic assertions.
+  configureApi("test-token", "http://127.0.0.1:8765");
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  // Restore the base URL that other test files may rely on.
+  configureApi("", ORIGINAL_BASE);
+});
+
+describe("configureApi", () => {
+  it("stores the token and base URL", () => {
+    configureApi("abc123", "http://example.test:9000");
+    expect(getApiBase()).toBe("http://example.test:9000");
+
+    const { calls } = captureFetch(jsonResponse({ ok: true }));
+    return getConfigStatus().then(() => {
+      expect(calls[0].url).toBe("http://example.test:9000/config/status");
+      expect(headerValue(calls[0].init, "X-GuildBotics-Session-Token")).toBe("abc123");
+    });
+  });
+
+  it("keeps the existing base URL when none is provided", () => {
+    configureApi("only-token");
+    expect(getApiBase()).toBe("http://127.0.0.1:8765");
+  });
+});
+
+describe("request headers and body", () => {
+  it("sends the session token and JSON content type on GET", async () => {
+    const { calls } = captureFetch(jsonResponse({ cwd: "/ws" }));
+    await getConfigStatus();
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe("http://127.0.0.1:8765/config/status");
+    expect(calls[0].init.method).toBe("GET");
+    expect(headerValue(calls[0].init, "Content-Type")).toBe("application/json");
+    expect(headerValue(calls[0].init, "X-GuildBotics-Session-Token")).toBe("test-token");
+    expect(calls[0].init.body).toBeUndefined();
+  });
+
+  it("serializes the body as JSON on POST", async () => {
+    const { calls } = captureFetch(jsonResponse({ cwd: "/ws" }));
+    await setWorkspace({ workspace_dir: "/projects/demo" });
+
+    expect(calls[0].url).toBe("http://127.0.0.1:8765/workspace");
+    expect(calls[0].init.method).toBe("POST");
+    expect(headerValue(calls[0].init, "X-GuildBotics-Session-Token")).toBe("test-token");
+    expect(calls[0].init.body).toBe(JSON.stringify({ workspace_dir: "/projects/demo" }));
+  });
+
+  it("omits the body for POST without a payload", async () => {
+    const { calls } = captureFetch(jsonResponse({ ok: true }));
+    await verify();
+
+    expect(calls[0].url).toBe("http://127.0.0.1:8765/verify");
+    expect(calls[0].init.method).toBe("POST");
+    expect(calls[0].init.body).toBeUndefined();
+  });
+});
+
+describe("GET query parameter encoding", () => {
+  it("encodes limit and path for getPromptTrace", async () => {
+    const { calls } = captureFetch(jsonResponse({ events: [] }));
+    await getPromptTrace(50, "/var/logs/trace file.jsonl");
+
+    const url = new URL(calls[0].url);
+    expect(url.pathname).toBe("/prompt-trace");
+    expect(url.searchParams.get("limit")).toBe("50");
+    expect(url.searchParams.get("path")).toBe("/var/logs/trace file.jsonl");
+    // The space must be percent-encoded in the raw query string.
+    expect(calls[0].url).toContain("trace+file.jsonl");
+  });
+
+  it("omits the path parameter when not provided", async () => {
+    const { calls } = captureFetch(jsonResponse({ events: [] }));
+    await getPromptTrace();
+
+    expect(calls[0].url).toBe("http://127.0.0.1:8765/prompt-trace?limit=20");
+  });
+
+  it("encodes person_id for runScenarioDiagnostics", async () => {
+    const { calls } = captureFetch(jsonResponse({ ok: true }));
+    await runScenarioDiagnostics("alice/dev");
+
+    expect(calls[0].url).toBe("http://127.0.0.1:8765/diagnostics/scenario?person_id=alice%2Fdev");
+    expect(calls[0].init.method).toBe("POST");
+  });
+
+  it("omits the query when runScenarioDiagnostics has no person id", async () => {
+    const { calls } = captureFetch(jsonResponse({ ok: true }));
+    await runScenarioDiagnostics();
+
+    expect(calls[0].url).toBe("http://127.0.0.1:8765/diagnostics/scenario");
+  });
+
+  it("encodes person_id for getIntelligenceConfig", async () => {
+    const { calls } = captureFetch(jsonResponse({ config_dir: "/c" }));
+    await getIntelligenceConfig("bob smith");
+
+    expect(calls[0].url).toBe("http://127.0.0.1:8765/config/intelligences?person_id=bob%20smith");
+  });
+
+  it("encodes person for getCommandOptions", async () => {
+    const { calls } = captureFetch(jsonResponse({ options: [] }));
+    await getCommandOptions("a&b");
+
+    expect(calls[0].url).toBe("http://127.0.0.1:8765/commands/options?person=a%26b");
+  });
+
+  it("omits the query when getCommandOptions has no person", async () => {
+    const { calls } = captureFetch(jsonResponse({ options: [] }));
+    await getCommandOptions();
+
+    expect(calls[0].url).toBe("http://127.0.0.1:8765/commands/options");
+  });
+
+  it("encodes the path segment for getMemberConfig", async () => {
+    const { calls } = captureFetch(jsonResponse({ person_id: "x" }));
+    await getMemberConfig("team/alice");
+
+    expect(calls[0].url).toBe("http://127.0.0.1:8765/config/members/team%2Falice");
+    expect(calls[0].init.method).toBe("GET");
+  });
+});
+
+describe("error handling", () => {
+  it("throws ApiRequestError with code, message and context on non-2xx", async () => {
+    const payload = {
+      code: "member_not_found",
+      message: "No such member",
+      context: { person_id: "ghost" },
+    };
+    captureFetch(jsonResponse(payload, { ok: false, status: 404 }));
+
+    const error = await getConfigStatus().catch((err) => err);
+    expect(error).toBeInstanceOf(ApiRequestError);
+    expect(error.name).toBe("ApiRequestError");
+    expect(error.code).toBe("member_not_found");
+    expect(error.message).toBe("No such member");
+    expect(error.context).toEqual({ person_id: "ghost" });
+  });
+
+  it("preserves validation-error context intact", async () => {
+    const context = {
+      errors: [{ loc: ["body", "person_id"], msg: "field required", type: "value_error.missing" }],
+      nested: { deep: [1, 2, 3] },
+    };
+    captureFetch(
+      jsonResponse(
+        { code: "validation_error", message: "Invalid request", context },
+        { ok: false, status: 422 },
+      ),
+    );
+
+    const error = await setWorkspace({ workspace_dir: "" }).catch((err) => err);
+    expect(error).toBeInstanceOf(ApiRequestError);
+    expect(error.code).toBe("validation_error");
+    expect(error.context).toEqual(context);
+  });
+
+  it("defaults context to an empty object when missing from payload", async () => {
+    captureFetch(jsonResponse({ code: "boom", message: "kaboom" }, { ok: false, status: 500 }));
+
+    const error = await getConfigStatus().catch((err) => err);
+    expect(error.code).toBe("boom");
+    expect(error.context).toEqual({});
+  });
+
+  it("falls back to an HTTP error when the body is not JSON", async () => {
+    const response = {
+      ok: false,
+      status: 502,
+      json: async () => {
+        throw new SyntaxError("Unexpected token < in JSON");
+      },
+      text: async () => "<html>Bad Gateway</html>",
+    } as unknown as Response;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => response),
+    );
+
+    const error = await getConfigStatus().catch((err) => err);
+    expect(error).toBeInstanceOf(ApiRequestError);
+    expect(error.code).toBe("http_error");
+    expect(error.message).toBe("HTTP 502");
+    expect(error.context).toEqual({});
+  });
+
+  it("falls back when the JSON payload lacks code or message", async () => {
+    captureFetch(jsonResponse({ detail: "nope" }, { ok: false, status: 400 }));
+
+    const error = await getConfigStatus().catch((err) => err);
+    expect(error.code).toBe("http_error");
+    expect(error.message).toBe("HTTP 400");
+  });
+});
+
+type SocketHandlers = {
+  onopen?: () => void;
+  onmessage?: (event: { data: string }) => void;
+  onerror?: () => void;
+  onclose?: () => void;
+};
+
+class MockWebSocket implements SocketHandlers {
+  static instances: MockWebSocket[] = [];
+  url: string;
+  close = vi.fn();
+  onopen?: () => void;
+  onmessage?: (event: { data: string }) => void;
+  onerror?: () => void;
+  onclose?: () => void;
+
+  constructor(url: string) {
+    this.url = url;
+    MockWebSocket.instances.push(this);
+  }
+}
+
+describe("websocket subscriptions", () => {
+  beforeEach(() => {
+    MockWebSocket.instances = [];
+    vi.stubGlobal("WebSocket", MockWebSocket as unknown as typeof WebSocket);
+  });
+
+  it("connects to /events with the token and drives status transitions", () => {
+    configureApi("ws-token", "http://127.0.0.1:8765");
+    const events: RuntimeEvent[] = [];
+    const statuses: StreamStatus[] = [];
+
+    const unsubscribe = subscribeEvents(
+      (event) => events.push(event),
+      (status) => statuses.push(status),
+    );
+
+    const socket = MockWebSocket.instances[0];
+    expect(socket.url).toBe("ws://127.0.0.1:8765/events?token=ws-token");
+    expect(statuses).toEqual(["connecting"]);
+
+    socket.onopen?.();
+    expect(statuses).toEqual(["connecting", "connected"]);
+
+    socket.onmessage?.({
+      data: JSON.stringify({
+        type: "task_started",
+        request_id: "r1",
+        payload: { id: 1 },
+        timestamp: "2026-06-05T00:00:00Z",
+      }),
+    });
+    expect(events).toEqual([
+      {
+        type: "task_started",
+        request_id: "r1",
+        payload: { id: 1 },
+        timestamp: "2026-06-05T00:00:00Z",
+      },
+    ]);
+
+    socket.onerror?.();
+    expect(statuses).toEqual(["connecting", "connected", "error"]);
+
+    socket.onclose?.();
+    expect(statuses).toEqual(["connecting", "connected", "error", "disconnected"]);
+
+    unsubscribe();
+    expect(socket.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("connects to /logs with the encoded token and parses log messages", () => {
+    configureApi("a b&c", "http://127.0.0.1:8765");
+    const logs: RuntimeLog[] = [];
+    const statuses: StreamStatus[] = [];
+
+    subscribeLogs(
+      (log) => logs.push(log),
+      (status) => statuses.push(status),
+    );
+
+    const socket = MockWebSocket.instances[0];
+    expect(socket.url).toBe("ws://127.0.0.1:8765/logs?token=a%20b%26c");
+    expect(statuses).toEqual(["connecting"]);
+
+    socket.onmessage?.({
+      data: JSON.stringify({
+        level: "INFO",
+        message: "hello",
+        request_id: null,
+        timestamp: "2026-06-05T00:00:00Z",
+      }),
+    });
+    expect(logs).toEqual([
+      { level: "INFO", message: "hello", request_id: null, timestamp: "2026-06-05T00:00:00Z" },
+    ]);
+  });
+
+  it("works without an onStatus callback", () => {
+    configureApi("ws-token", "http://127.0.0.1:8765");
+    expect(() => subscribeEvents(() => undefined)).not.toThrow();
+    const socket = MockWebSocket.instances[0];
+    expect(() => socket.onopen?.()).not.toThrow();
+    expect(() => socket.onerror?.()).not.toThrow();
+    expect(() => socket.onclose?.()).not.toThrow();
+  });
+});
+
+describe("websocketBase protocol conversion", () => {
+  beforeEach(() => {
+    MockWebSocket.instances = [];
+    vi.stubGlobal("WebSocket", MockWebSocket as unknown as typeof WebSocket);
+  });
+
+  it("converts http:// to ws://", () => {
+    configureApi("t", "http://localhost:1234");
+    subscribeEvents(() => undefined);
+    expect(MockWebSocket.instances[0].url).toBe("ws://localhost:1234/events?token=t");
+  });
+
+  it("converts https:// to wss:// and strips the trailing slash", () => {
+    configureApi("t", "https://api.example.com");
+    subscribeEvents(() => undefined);
+    expect(MockWebSocket.instances[0].url).toBe("wss://api.example.com/events?token=t");
+  });
+});

--- a/desktop/src/i18n.test.ts
+++ b/desktop/src/i18n.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import i18n, { getInitialAppLanguage, normalizeLanguage, setAppLanguage } from "./i18n";
 
@@ -20,13 +20,97 @@ describe("normalizeLanguage", () => {
   });
 });
 
+describe("getInitialAppLanguage", () => {
+  const originalDescriptor = Object.getOwnPropertyDescriptor(window.navigator, "language");
+
+  function mockNavigatorLanguage(value: string) {
+    Object.defineProperty(window.navigator, "language", {
+      configurable: true,
+      get: () => value,
+    });
+  }
+
+  beforeEach(() => {
+    localStorage.clear();
+    mockNavigatorLanguage("en-US");
+  });
+
+  afterEach(() => {
+    if (originalDescriptor) {
+      Object.defineProperty(window.navigator, "language", originalDescriptor);
+    }
+    localStorage.clear();
+  });
+
+  it("uses a valid stored language", () => {
+    localStorage.setItem("guildbotics.appLanguage", "ja");
+    expect(getInitialAppLanguage()).toBe("ja");
+  });
+
+  it("falls back to navigator language when storage holds an invalid value", () => {
+    localStorage.setItem("guildbotics.appLanguage", "fr");
+    mockNavigatorLanguage("ja-JP");
+    expect(getInitialAppLanguage()).toBe("ja");
+  });
+
+  it("falls back to en when both storage and navigator are unsupported", () => {
+    localStorage.setItem("guildbotics.appLanguage", "fr");
+    mockNavigatorLanguage("fr-FR");
+    expect(getInitialAppLanguage()).toBe("en");
+  });
+
+  it("uses navigator language when storage is empty", () => {
+    mockNavigatorLanguage("ja");
+    expect(getInitialAppLanguage()).toBe("ja");
+  });
+});
+
 describe("app language storage", () => {
+  afterEach(async () => {
+    localStorage.clear();
+    await setAppLanguage("en");
+  });
+
   it("persists the selected application language", async () => {
     localStorage.clear();
 
     await setAppLanguage("ja");
 
+    expect(localStorage.getItem("guildbotics.appLanguage")).toBe("ja");
     expect(getInitialAppLanguage()).toBe("ja");
     expect(i18n.language).toBe("ja");
+  });
+
+  it("updates both localStorage and i18next state when switching back", async () => {
+    await setAppLanguage("ja");
+    await setAppLanguage("en");
+
+    expect(localStorage.getItem("guildbotics.appLanguage")).toBe("en");
+    expect(i18n.language).toBe("en");
+  });
+});
+
+describe("i18n resources", () => {
+  function collectKeys(node: unknown, prefix = ""): string[] {
+    if (node && typeof node === "object" && !Array.isArray(node)) {
+      return Object.entries(node as Record<string, unknown>).flatMap(([key, value]) =>
+        collectKeys(value, prefix ? `${prefix}.${key}` : key),
+      );
+    }
+    return [prefix];
+  }
+
+  it("has identical translation keys between en and ja", () => {
+    const en = i18n.getResourceBundle("en", "translation") as Record<string, unknown>;
+    const ja = i18n.getResourceBundle("ja", "translation") as Record<string, unknown>;
+
+    const enKeys = collectKeys(en).sort();
+    const jaKeys = collectKeys(ja).sort();
+
+    const missingInJa = enKeys.filter((key) => !jaKeys.includes(key));
+    const missingInEn = jaKeys.filter((key) => !enKeys.includes(key));
+
+    expect(missingInJa).toEqual([]);
+    expect(missingInEn).toEqual([]);
   });
 });

--- a/desktop/src/integration/ApiIntegration.test.tsx
+++ b/desktop/src/integration/ApiIntegration.test.tsx
@@ -1,0 +1,581 @@
+import { MantineProvider, createTheme } from "@mantine/core";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { App } from "../App";
+import { configureApi } from "../api/client";
+import i18n from "../i18n";
+import "../i18n";
+import { SetupPage } from "../setup/SetupPage";
+
+const t = i18n.getFixedT("en");
+const BASE = "http://127.0.0.1:8765";
+const TOKEN = "integration-token";
+
+// jsdom lacks scrollIntoView, which Mantine's Combobox calls when opening a Select.
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = vi.fn();
+}
+
+vi.mock("@tauri-apps/plugin-shell", () => ({ open: vi.fn() }));
+vi.mock("@tauri-apps/plugin-dialog", () => ({ open: vi.fn(), save: vi.fn() }));
+
+// ---------------------------------------------------------------------------
+// Mock HTTP boundary: a recording fetch that matches "METHOD /pathname" against
+// a route table and returns canned JSON. The real api/client builds the request
+// (URL, method, headers, JSON body, query string), so every recorded call
+// reflects exactly what the client would send over the wire.
+// ---------------------------------------------------------------------------
+
+type RecordedRequest = {
+  method: string;
+  url: string;
+  pathname: string;
+  query: URLSearchParams;
+  headers: Record<string, string>;
+  body: unknown;
+};
+
+type RouteHandler = (req: RecordedRequest) => { status?: number; body: unknown };
+
+class MockServer {
+  routes = new Map<string, RouteHandler>();
+  requests: RecordedRequest[] = [];
+
+  on(method: string, pathname: string, handler: RouteHandler): this {
+    this.routes.set(`${method} ${pathname}`, handler);
+    return this;
+  }
+
+  json(method: string, pathname: string, body: unknown): this {
+    return this.on(method, pathname, () => ({ body }));
+  }
+
+  requestsFor(method: string, pathname: string): RecordedRequest[] {
+    return this.requests.filter((r) => r.method === method && r.pathname === pathname);
+  }
+
+  lastBody(method: string, pathname: string): unknown {
+    const matches = this.requestsFor(method, pathname);
+    return matches[matches.length - 1]?.body;
+  }
+
+  private handle(input: string, init?: RequestInit): Response {
+    const url = new URL(input);
+    const method = (init?.method ?? "GET").toUpperCase();
+    const headers = (init?.headers as Record<string, string>) ?? {};
+    const body = init?.body == null ? undefined : JSON.parse(String(init.body));
+    const record: RecordedRequest = {
+      method,
+      url: input,
+      pathname: url.pathname,
+      query: url.searchParams,
+      headers,
+      body,
+    };
+    this.requests.push(record);
+
+    if (url.pathname === "/health") {
+      return jsonResponse(200, { status: "ok" });
+    }
+    const handler = this.routes.get(`${method} ${url.pathname}`);
+    if (!handler) {
+      return jsonResponse(404, {
+        code: "not_found",
+        message: `No mock route for ${method} ${url.pathname}`,
+        context: {},
+      });
+    }
+    const result = handler(record);
+    return jsonResponse(result.status ?? 200, result.body);
+  }
+
+  install(): void {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string, init?: RequestInit) => this.handle(input, init)),
+    );
+  }
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+// ---------------------------------------------------------------------------
+// Mock WebSocket boundary: a controllable fake the test can push events into.
+// ---------------------------------------------------------------------------
+
+class FakeWebSocket {
+  static instances: FakeWebSocket[] = [];
+  url: string;
+  close = vi.fn();
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+
+  constructor(url: string) {
+    this.url = url;
+    FakeWebSocket.instances.push(this);
+  }
+
+  emit(payload: unknown): void {
+    this.onmessage?.({ data: JSON.stringify(payload) });
+  }
+
+  static find(suffix: string): FakeWebSocket {
+    const socket = FakeWebSocket.instances.find((s) => s.url.includes(suffix));
+    if (!socket) {
+      throw new Error(`No websocket opened for ${suffix}`);
+    }
+    return socket;
+  }
+}
+
+function installWebSocket(): void {
+  FakeWebSocket.instances = [];
+  vi.stubGlobal("WebSocket", FakeWebSocket as unknown as typeof WebSocket);
+}
+
+// ---------------------------------------------------------------------------
+// Canned response factories.
+// ---------------------------------------------------------------------------
+
+function configStatus(overrides: Record<string, unknown> = {}) {
+  return {
+    cwd: "/workspace",
+    env_file: "/workspace/.env",
+    env_file_exists: true,
+    primary_config_dir: "/workspace/.guildbotics/config",
+    primary_config_location: "workspace",
+    primary_project_file: "/workspace/.guildbotics/config/project.yml",
+    primary_project_file_exists: true,
+    home_config_dir: "/home/.guildbotics/config",
+    home_project_file: "/home/.guildbotics/config/project.yml",
+    home_project_file_exists: false,
+    active_config_dir: "/workspace/.guildbotics/config",
+    active_config_location: "workspace",
+    storage_dir: "/workspace/.guildbotics",
+    ...overrides,
+  };
+}
+
+function projectConfig(overrides: Record<string, unknown> = {}) {
+  return {
+    config_dir: "/workspace/.guildbotics/config",
+    env_file_path: "/workspace/.env",
+    language: "en",
+    description: "Demo project",
+    llm_api_type: "openai",
+    cli_agent: "codex",
+    github_enabled: false,
+    github_project_url: "",
+    github_repository_url: "",
+    repo_base_url: "https://github.com",
+    has_google_api_key: false,
+    has_openai_api_key: true,
+    has_anthropic_api_key: false,
+    ...overrides,
+  };
+}
+
+function team(overrides: Record<string, unknown> = {}) {
+  return {
+    project: { name: "Demo", language_code: "en", language_name: "English" },
+    members: [{ person_id: "alice", name: "Alice", is_active: true, roles: ["professional"] }],
+    ...overrides,
+  };
+}
+
+function runtimeUnit(target: "scheduler" | "events", overrides: Record<string, unknown> = {}) {
+  return {
+    target,
+    state: "stopped",
+    running: false,
+    started_at: null,
+    stopped_at: null,
+    error: null,
+    routine_commands: [],
+    max_consecutive_errors: null,
+    routine_interval_minutes: null,
+    active_member_count: 1,
+    worker_count: 0,
+    workflow_command: null,
+    subscription_count: 0,
+    listener_count: 0,
+    cycle_count: 0,
+    cycle_failure_count: 0,
+    events_drained_count: 0,
+    events_delivered_count: 0,
+    events_skipped_processed_count: 0,
+    ...overrides,
+  };
+}
+
+function runtimeStatus(overrides: Record<string, unknown> = {}) {
+  return {
+    scheduler: runtimeUnit("scheduler"),
+    events: runtimeUnit("events"),
+    ...overrides,
+  };
+}
+
+function promptTrace() {
+  return {
+    enabled: false,
+    env_file: "",
+    env_file_exists: false,
+    trace_file: "",
+    output_trace_file: "",
+    default_trace_file: "",
+    trace_file_exists: false,
+    event_count: 0,
+    events: [],
+  };
+}
+
+function catalogCommand(overrides: Record<string, unknown> = {}) {
+  return {
+    command: "workflows/sample",
+    label: "Sample workflow",
+    description: "A sample command",
+    category: "workflow",
+    source: "workspace",
+    path: "/workspace/commands/sample.py",
+    arguments: [
+      { name: "topic", kind: "positional", required: true, default: "" },
+      { name: "mode", kind: "keyword", required: false, default: "" },
+    ],
+    supports_raw_args: true,
+    recommended_input: "",
+    requirements: [],
+    ...overrides,
+  };
+}
+
+function configWriteResponse() {
+  return { project: null, member: null, intelligence: null };
+}
+
+// Wire up the routes the App/Setup pages need so we can drive the UI. Each test
+// overrides only the specific responses it asserts against.
+function serviceServer(): MockServer {
+  return new MockServer()
+    .json("GET", "/config/status", configStatus())
+    .json("GET", "/team", team())
+    .json("GET", "/scheduler/routines", {
+      routines: [{ command: "workflows/ticket_driven_workflow", requires_github: false }],
+    })
+    .json("GET", "/scheduler/status", runtimeStatus())
+    .json("GET", "/config/project", projectConfig())
+    .json("GET", "/commands/options", { options: [] })
+    .json("GET", "/prompt-trace", promptTrace())
+    .json("POST", "/scheduler/start", runtimeStatus())
+    .json("POST", "/scheduler/stop", runtimeStatus());
+}
+
+function renderApp(server: MockServer, path: string) {
+  server.install();
+  installWebSocket();
+  configureApi(TOKEN, BASE);
+  const theme = createTheme({ primaryColor: "dark", defaultRadius: "md" });
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <MantineProvider theme={theme}>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[path]}>
+          <App />
+        </MemoryRouter>
+      </QueryClientProvider>
+    </MantineProvider>,
+  );
+}
+
+function renderSetup(server: MockServer, path: string) {
+  server.install();
+  installWebSocket();
+  configureApi(TOKEN, BASE);
+  const theme = createTheme({ primaryColor: "dark", defaultRadius: "md" });
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <MantineProvider theme={theme}>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter
+          future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
+          initialEntries={[path]}
+        >
+          <SetupPage />
+        </MemoryRouter>
+      </QueryClientProvider>
+    </MantineProvider>,
+  );
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  configureApi(TOKEN, BASE);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  Reflect.deleteProperty(window, "__TAURI_INTERNALS__");
+  configureApi("", BASE);
+});
+
+describe("Service Runtime integration (real client + mock server)", () => {
+  it("sends the real POST /scheduler/start with token, JSON body, only and routine_commands", async () => {
+    const server = serviceServer();
+    const user = userEvent.setup();
+    renderApp(server, "/service");
+    await screen.findByRole("heading", { name: t("service.title") });
+
+    await user.click(screen.getByRole("button", { name: t("overview.start") }));
+
+    await waitFor(() => expect(server.requestsFor("POST", "/scheduler/start")).toHaveLength(1));
+    const call = server.requestsFor("POST", "/scheduler/start")[0];
+    expect(call.url).toBe(`${BASE}/scheduler/start`);
+    expect(call.headers["X-GuildBotics-Session-Token"]).toBe(TOKEN);
+    expect(call.headers["Content-Type"]).toBe("application/json");
+    expect(call.body).toMatchObject({
+      routine_commands: ["workflows/ticket_driven_workflow"],
+      routine_interval_minutes: expect.any(Number),
+      max_consecutive_errors: expect.any(Number),
+    });
+    // Both targets enabled by default -> no `only` selector.
+    expect(call.body).not.toHaveProperty("only");
+  });
+
+  it("encodes only=scheduler and the edited interval / max errors into the start body", async () => {
+    const server = serviceServer();
+    const user = userEvent.setup();
+    renderApp(server, "/service");
+    await screen.findByRole("heading", { name: t("service.title") });
+
+    const eventsSwitch = screen
+      .getByText(t("overview.eventsCard.title"))
+      .closest(".service-unit-panel")
+      ?.querySelector('[role="switch"]') as HTMLElement;
+    await user.click(eventsSwitch);
+
+    const interval = screen.getByRole("textbox", { name: t("overview.routineIntervalMinutes") });
+    await user.clear(interval);
+    await user.type(interval, "30");
+    const maxErrors = screen.getByRole("textbox", { name: t("overview.maxConsecutiveErrors") });
+    await user.clear(maxErrors);
+    await user.type(maxErrors, "7");
+
+    await user.click(screen.getByRole("button", { name: t("overview.start") }));
+
+    await waitFor(() => expect(server.requestsFor("POST", "/scheduler/start")).toHaveLength(1));
+    expect(server.lastBody("POST", "/scheduler/start")).toMatchObject({
+      only: "scheduler",
+      routine_interval_minutes: 30,
+      max_consecutive_errors: 7,
+      routine_commands: ["workflows/ticket_driven_workflow"],
+    });
+  });
+
+  it("omits routine_commands and sends only=events for the events-only target", async () => {
+    const server = serviceServer();
+    const user = userEvent.setup();
+    renderApp(server, "/service");
+    await screen.findByRole("heading", { name: t("service.title") });
+
+    const schedulerSwitch = screen
+      .getByText(t("overview.schedulerCard.title"))
+      .closest(".service-unit-panel")
+      ?.querySelector('[role="switch"]') as HTMLElement;
+    await user.click(schedulerSwitch);
+
+    await user.click(screen.getByRole("button", { name: t("overview.start") }));
+
+    await waitFor(() => expect(server.requestsFor("POST", "/scheduler/start")).toHaveLength(1));
+    const body = server.lastBody("POST", "/scheduler/start") as Record<string, unknown>;
+    expect(body).toMatchObject({ only: "events" });
+    expect(body).not.toHaveProperty("routine_commands");
+  });
+
+  it("sends the real POST /scheduler/stop with the token when running", async () => {
+    const server = serviceServer();
+    server.json(
+      "GET",
+      "/scheduler/status",
+      runtimeStatus({ scheduler: runtimeUnit("scheduler", { state: "running", running: true }) }),
+    );
+    const user = userEvent.setup();
+    renderApp(server, "/service");
+    await screen.findByRole("heading", { name: t("service.title") });
+
+    await user.click(await screen.findByRole("button", { name: t("overview.stop") }));
+
+    await waitFor(() => expect(server.requestsFor("POST", "/scheduler/stop")).toHaveLength(1));
+    const call = server.requestsFor("POST", "/scheduler/stop")[0];
+    expect(call.url).toBe(`${BASE}/scheduler/stop`);
+    expect(call.headers["X-GuildBotics-Session-Token"]).toBe(TOKEN);
+    expect(call.body).toBeUndefined();
+  });
+
+  it("surfaces an ApiRequestError from a non-2xx /scheduler/start as a UI alert", async () => {
+    const server = serviceServer();
+    server.on("POST", "/scheduler/start", () => ({
+      status: 409,
+      body: { code: "scheduler_running", message: "already running", context: {} },
+    }));
+    const user = userEvent.setup();
+    renderApp(server, "/service");
+    await screen.findByRole("heading", { name: t("service.title") });
+
+    await user.click(screen.getByRole("button", { name: t("overview.start") }));
+
+    expect(await screen.findByText(t("overview.startError"))).toBeInTheDocument();
+    expect(screen.getByText("already running")).toBeInTheDocument();
+  });
+});
+
+describe("Setup integration (real client + mock server)", () => {
+  it("drives first-time setup to a member add and project init with real requests", async () => {
+    Object.defineProperty(window, "__TAURI_INTERNALS__", { value: {}, configurable: true });
+    const server = new MockServer()
+      .json("GET", "/config/status", configStatus({ primary_project_file_exists: false }))
+      .json("POST", "/workspace", configStatus({ primary_project_file_exists: false }))
+      .on("GET", "/team", () => ({
+        status: 404,
+        body: { code: "not_found", message: "missing", context: {} },
+      }))
+      .json("GET", "/config/project", projectConfig())
+      .json("GET", "/commands/options", { options: [] })
+      .json("GET", "/intelligences/cli-agents/detection", {
+        agents: [{ name: "codex", executable: "codex", detected: true, path: "/usr/bin/codex" }],
+      })
+      .json("GET", "/config/roles", {
+        roles: [{ role_id: "professional", summary: "Professional", description: "" }],
+      })
+      .json("POST", "/config/members", configWriteResponse())
+      .json("POST", "/config/init", configWriteResponse());
+    const user = userEvent.setup();
+    renderSetup(server, "/setup");
+
+    await screen.findByRole("heading", { name: "First setup" });
+    await waitFor(() =>
+      expect(screen.getByLabelText("Working directory")).toHaveValue("/workspace"),
+    );
+
+    await user.type(screen.getByLabelText("Project description"), "Demo project");
+    await user.click(screen.getByRole("button", { name: "LLM / CLI agent" }));
+    await user.type(await screen.findByLabelText("OpenAI API key"), "sk-test");
+    await user.click(screen.getByRole("button", { name: "GitHub" }));
+    await user.click(await screen.findByRole("textbox", { name: "GitHub integration" }));
+    await user.click(await screen.findByRole("option", { name: "Do not use GitHub" }));
+
+    await user.click(screen.getByRole("button", { name: "Members" }));
+    await user.type(await screen.findByLabelText("Member ID"), "alice");
+    await user.type(screen.getByLabelText("Display name"), "Alice");
+    await user.click(screen.getByRole("button", { name: "Add member" }));
+
+    // The real POST /config/members request is built and sent by the client.
+    await waitFor(() => expect(server.requestsFor("POST", "/config/members")).toHaveLength(1));
+    const memberCall = server.requestsFor("POST", "/config/members")[0];
+    expect(memberCall.url).toBe(`${BASE}/config/members`);
+    expect(memberCall.headers["X-GuildBotics-Session-Token"]).toBe(TOKEN);
+    expect(memberCall.body).toMatchObject({
+      person_id: "alice",
+      person_name: "Alice",
+      is_active: true,
+      config_dir: "/workspace/.guildbotics/config",
+      env_file_path: "/workspace/.env",
+    });
+
+    const createButton = await screen.findByRole("button", { name: t("setup.saveInitial") });
+    await user.click(createButton);
+
+    await waitFor(() => expect(server.requestsFor("POST", "/config/init")).toHaveLength(1));
+    const initCall = server.requestsFor("POST", "/config/init")[0];
+    expect(initCall.url).toBe(`${BASE}/config/init`);
+    expect(initCall.headers["X-GuildBotics-Session-Token"]).toBe(TOKEN);
+    expect(initCall.body).toMatchObject({
+      description: "Demo project",
+      llm_api_type: "openai",
+      cli_agent: "codex",
+      owner: "",
+      repository_name: "",
+      github_project_url: "",
+      openai_api_key: "sk-test",
+    });
+
+    // restartBackend -> setWorkspace fires a real POST /workspace.
+    await waitFor(() => expect(server.requestsFor("POST", "/workspace")).toHaveLength(1));
+    expect(server.lastBody("POST", "/workspace")).toEqual({ workspace_dir: "/workspace" });
+    expect(localStorage.getItem("guildbotics.workspace")).toBe("/workspace");
+    expect(await screen.findByText(t("setup.initialCreated.title"))).toBeInTheDocument();
+  });
+});
+
+describe("Commands integration (real client + mock server)", () => {
+  it("sends real GET /commands/options + POST /commands/run and updates history from websocket events", async () => {
+    const server = new MockServer()
+      .json("GET", "/config/status", configStatus())
+      .json("GET", "/team", team())
+      .json("GET", "/prompt-trace", promptTrace())
+      .json("POST", "/commands/run", { request_id: "req-1", output: "hello output" })
+      .on("GET", "/commands/options", () => ({ body: { options: [catalogCommand()] } }));
+    const user = userEvent.setup();
+    renderApp(server, "/commands");
+    await screen.findByRole("heading", { name: t("commands.title") });
+
+    // The real GET /commands/options request is built and sent by the client.
+    // The catalog loads before a person is explicitly chosen, so no `person`
+    // query param is present, but the session token header is.
+    await waitFor(() =>
+      expect(server.requestsFor("GET", "/commands/options").length).toBeGreaterThan(0),
+    );
+    const optionsCall = server.requestsFor("GET", "/commands/options")[0];
+    expect(optionsCall.url).toBe(`${BASE}/commands/options`);
+    expect(optionsCall.query.has("person")).toBe(false);
+    expect(optionsCall.headers["X-GuildBotics-Session-Token"]).toBe(TOKEN);
+
+    await user.type(await screen.findByRole("textbox", { name: "topic *" }), " release ");
+    await user.type(screen.getByRole("textbox", { name: "mode" }), "fast");
+    await user.click(screen.getByRole("button", { name: t("commands.run") }));
+
+    await waitFor(() => expect(server.requestsFor("POST", "/commands/run")).toHaveLength(1));
+    const runCall = server.requestsFor("POST", "/commands/run")[0];
+    expect(runCall.url).toBe(`${BASE}/commands/run`);
+    expect(runCall.headers["X-GuildBotics-Session-Token"]).toBe(TOKEN);
+    expect(runCall.body).toMatchObject({
+      command: "workflows/sample",
+      args: ["release", "mode=fast"],
+      person: "alice",
+    });
+
+    // A pushed command lifecycle event over the (real-client) websocket drives
+    // the history UI. The client opens /events with the encoded token.
+    const socket = FakeWebSocket.find(`/events?token=${TOKEN}`);
+    await waitFor(() => expect(socket.onmessage).not.toBeNull());
+
+    socket.emit({
+      type: "command.started",
+      request_id: "evt-1",
+      payload: { command: "workflows/sample", person: "alice" },
+      timestamp: "2026-06-04T01:00:00Z",
+    });
+    expect(await screen.findByText(t("commands.status.running"))).toBeInTheDocument();
+
+    socket.emit({
+      type: "command.finished",
+      request_id: "evt-1",
+      payload: { command: "workflows/sample", person: "alice" },
+      timestamp: "2026-06-04T01:00:01Z",
+    });
+    expect(await screen.findByText(t("commands.status.success"))).toBeInTheDocument();
+  });
+});

--- a/desktop/src/setup/SetupPage.test.tsx
+++ b/desktop/src/setup/SetupPage.test.tsx
@@ -1,15 +1,71 @@
 import { MantineProvider, createTheme } from "@mantine/core";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { SetupPage } from "./SetupPage";
+import {
+  addMemberConfig,
+  ApiRequestError,
+  deleteMemberConfig,
+  getCliAgentDetections,
+  getCommandOptions,
+  getConfigStatus,
+  getIntelligenceConfig,
+  getMemberConfig,
+  getProjectConfig,
+  getRoleOptions,
+  getTeam,
+  initConfig,
+  resolveMemberIdentity,
+  runScenarioDiagnostics,
+  updateIntelligenceConfig,
+  updateMemberConfig,
+  updateProjectConfig,
+  type CommandOption,
+  type ConfigStatus,
+  type IntelligenceConfig,
+  type MemberConfig,
+} from "../api/client";
+import { restartBackend } from "../api/backend";
+import i18n from "../i18n";
+import {
+  type ScheduledCommandDraft,
+  SetupPage,
+  buildCharacterPayload,
+  buildScheduledCommandExpression,
+  buildTaskSchedules,
+  createProjectSchema,
+  createScheduledCommandDraft,
+  draftToCron,
+  getMemberFieldErrors,
+  getMemberResolveErrorMessage,
+  initialProjectValues,
+  isValidCron,
+  parseCharacterFields,
+  parseCommandExpression,
+  parseCron,
+  parseGitHub,
+  quoteCommandArg,
+  splitCommandLine,
+  toIntelligenceUpdatePayload,
+  toProjectSetupRequest,
+  toProjectUpdateRequest,
+} from "./SetupPage";
 import "../i18n";
+
+const t = i18n.getFixedT("en");
+const dialogMock = vi.hoisted(() => ({
+  open: vi.fn(async () => null as string | null),
+}));
 
 vi.mock("../api/backend", () => ({
   restartBackend: vi.fn(async () => undefined),
+}));
+
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  open: dialogMock.open,
 }));
 
 vi.mock("../api/client", async (importOriginal) => {
@@ -113,6 +169,27 @@ vi.mock("../api/client", async (importOriginal) => {
   };
 });
 
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  // Restore the default existing-project responses so that first-setup tests,
+  // which install persistent `mockResolvedValue` overrides, do not leak into
+  // subsequent existing-project tests.
+  vi.mocked(getConfigStatus).mockResolvedValue(configStatus({ primary_project_file_exists: true }));
+  vi.mocked(getTeam).mockResolvedValue({
+    project: { name: "Demo", language_code: "en", language_name: "English" },
+    members: [{ person_id: "alice", name: "Alice", is_active: true, roles: ["professional"] }],
+  });
+  vi.mocked(getProjectConfig).mockResolvedValue(projectConfig({ description: "Demo project" }));
+  vi.mocked(getCliAgentDetections).mockResolvedValue({
+    agents: [{ name: "codex", executable: "codex", detected: true, path: "/usr/local/bin/codex" }],
+  });
+});
+
+afterEach(() => {
+  Reflect.deleteProperty(window, "__TAURI_INTERNALS__");
+});
+
 describe("SetupPage", () => {
   it("allows sidebar navigation after opening a members deep link", async () => {
     const user = userEvent.setup();
@@ -124,6 +201,279 @@ describe("SetupPage", () => {
 
     expect(await screen.findByLabelText("Working directory")).toBeInTheDocument();
     expect(screen.queryByText("Alice (alice)")).not.toBeInTheDocument();
+  });
+
+  it("switches from settings mode to first setup mode when the selected workspace is unconfigured", async () => {
+    const user = userEvent.setup();
+    Object.defineProperty(window, "__TAURI_INTERNALS__", { value: {}, configurable: true });
+    renderSetupPage("/setup");
+
+    expect(await screen.findByRole("heading", { name: "Settings" })).toBeInTheDocument();
+
+    dialogMock.open.mockResolvedValueOnce("/empty-workspace");
+    vi.mocked(getConfigStatus).mockResolvedValueOnce(
+      configStatus({
+        cwd: "/empty-workspace",
+        env_file: "/empty-workspace/.env",
+        env_file_exists: false,
+        primary_config_dir: "/empty-workspace/.guildbotics/config",
+        primary_project_file: "/empty-workspace/.guildbotics/config/team/project.yml",
+        primary_project_file_exists: false,
+        home_project_file_exists: false,
+        active_config_dir: null,
+        active_config_location: "missing",
+      }),
+    );
+    vi.mocked(getTeam).mockRejectedValueOnce(new Error("project config missing"));
+
+    await user.click(screen.getByRole("button", { name: "Choose" }));
+
+    await waitFor(() => expect(restartBackend).toHaveBeenCalledWith("/empty-workspace"));
+    expect(await screen.findByRole("heading", { name: "First setup" })).toBeInTheDocument();
+    expect(screen.getByText("Input progress: 0 of 4 sections completed")).toBeInTheDocument();
+    expect(screen.getByLabelText("Working directory")).toHaveValue("/empty-workspace");
+  });
+
+  it("switches from first setup mode to settings mode when the selected workspace is configured", async () => {
+    const user = userEvent.setup();
+    Object.defineProperty(window, "__TAURI_INTERNALS__", { value: {}, configurable: true });
+    vi.mocked(getConfigStatus).mockResolvedValueOnce(
+      configStatus({
+        cwd: "/empty-workspace",
+        env_file: "/empty-workspace/.env",
+        env_file_exists: false,
+        primary_config_dir: "/empty-workspace/.guildbotics/config",
+        primary_project_file: "/empty-workspace/.guildbotics/config/team/project.yml",
+        primary_project_file_exists: false,
+        home_project_file_exists: false,
+        active_config_dir: null,
+        active_config_location: "missing",
+      }),
+    );
+    renderSetupPage("/setup");
+
+    expect(await screen.findByRole("heading", { name: "First setup" })).toBeInTheDocument();
+
+    dialogMock.open.mockResolvedValueOnce("/configured-workspace");
+    vi.mocked(getConfigStatus).mockResolvedValueOnce(
+      configStatus({
+        cwd: "/configured-workspace",
+        env_file: "/configured-workspace/.env",
+        env_file_exists: true,
+        primary_config_dir: "/configured-workspace/.guildbotics/config",
+        primary_project_file: "/configured-workspace/.guildbotics/config/team/project.yml",
+        primary_project_file_exists: true,
+        home_project_file_exists: false,
+        active_config_dir: "/configured-workspace/.guildbotics/config",
+        active_config_location: "workspace",
+      }),
+    );
+    vi.mocked(getProjectConfig).mockResolvedValueOnce(
+      projectConfig({
+        config_dir: "/configured-workspace/.guildbotics/config",
+        env_file_path: "/configured-workspace/.env",
+        description: "Configured workspace",
+      }),
+    );
+    vi.mocked(getTeam).mockResolvedValueOnce({
+      project: { name: "Configured", language_code: "en", language_name: "English" },
+      members: [{ person_id: "bob", name: "Bob", is_active: true, roles: ["professional"] }],
+    });
+
+    await user.click(screen.getByRole("button", { name: "Choose" }));
+
+    await waitFor(() => expect(restartBackend).toHaveBeenCalledWith("/configured-workspace"));
+    expect(await screen.findByRole("heading", { name: "Settings" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Working directory")).toHaveValue("/configured-workspace");
+  });
+
+  it("renders the first-setup required progress and project section fields", async () => {
+    vi.mocked(getConfigStatus).mockResolvedValue(
+      configStatus({ primary_project_file_exists: false, home_project_file_exists: false }),
+    );
+    vi.mocked(getTeam).mockRejectedValue(
+      new ApiRequestError({ code: "not_found", message: "missing", context: {} }),
+    );
+    renderSetupPage("/setup");
+
+    expect(await screen.findByRole("heading", { name: "First setup" })).toBeInTheDocument();
+    expect(screen.getByText("Input progress: 0 of 4 sections completed")).toBeInTheDocument();
+    expect(screen.getByText(t("setup.saveMode.manual"))).toBeInTheDocument();
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("Working directory")).toHaveValue("/workspace"),
+    );
+    // In first-setup mode the existing project config is not loaded, so the
+    // description starts empty.
+    expect(screen.getByLabelText("Project description")).toHaveValue("");
+    expect(screen.getByText(t("setup.project.agentLanguage"))).toBeInTheDocument();
+    expect(screen.getByText(t("setup.project.configLocation"))).toBeInTheDocument();
+  });
+
+  it("shows the LLM provider and CLI agent selection with API-key availability", async () => {
+    const user = userEvent.setup();
+    vi.mocked(getConfigStatus).mockResolvedValue(
+      configStatus({ primary_project_file_exists: false, home_project_file_exists: false }),
+    );
+    vi.mocked(getTeam).mockRejectedValue(
+      new ApiRequestError({ code: "not_found", message: "missing", context: {} }),
+    );
+    renderSetupPage("/setup");
+
+    await screen.findByRole("heading", { name: "First setup" });
+    await user.click(screen.getByRole("button", { name: "LLM / CLI agent" }));
+
+    expect(await screen.findByText(t("setup.intelligence.defaultProvider"))).toBeInTheDocument();
+    // The provider buttons expose "<label><family>" as their accessible name
+    // (e.g. "OpenAIGPT"); anchor the match so the OpenAI provider is not
+    // confused with the "OpenAI Codex CLI" agent button.
+    expect(screen.getByRole("button", { name: /^OpenAIGPT$/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Anthropic ClaudeClaude$/ })).toBeInTheDocument();
+
+    const keyInput = screen.getByLabelText("OpenAI API key");
+    await user.type(keyInput, "sk-test");
+    expect(keyInput).toHaveValue("sk-test");
+
+    expect(screen.getByRole("button", { name: /OpenAI Codex CLI/ })).toBeEnabled();
+    expect(screen.getByRole("button", { name: /Claude Code/ })).toBeDisabled();
+  });
+
+  it("marks GitHub section ready for the disabled decision and incomplete when enabled without URLs", async () => {
+    const user = userEvent.setup();
+    vi.mocked(getConfigStatus).mockResolvedValue(
+      configStatus({ primary_project_file_exists: false, home_project_file_exists: false }),
+    );
+    vi.mocked(getTeam).mockRejectedValue(
+      new ApiRequestError({ code: "not_found", message: "missing", context: {} }),
+    );
+    renderSetupPage("/setup");
+
+    await screen.findByRole("heading", { name: "First setup" });
+    await user.click(screen.getByRole("button", { name: "GitHub" }));
+
+    // The decision control is a Mantine Select; its hidden listbox shares the
+    // accessible label, so target the input via its textbox role.
+    const decision = await screen.findByRole("textbox", { name: "GitHub integration" });
+    await user.click(decision);
+    await user.click(await screen.findByRole("option", { name: "Use GitHub" }));
+    expect(screen.getByLabelText(t("setup.github.projectUrl"))).toBeEnabled();
+
+    await user.click(decision);
+    await user.click(await screen.findByRole("option", { name: "Do not use GitHub" }));
+    expect(screen.getByText(t("setup.github.disabledHint"))).toBeInTheDocument();
+  });
+
+  it("navigates between sections with the next and back buttons", async () => {
+    const user = userEvent.setup();
+    vi.mocked(getConfigStatus).mockResolvedValue(
+      configStatus({ primary_project_file_exists: false, home_project_file_exists: false }),
+    );
+    vi.mocked(getTeam).mockRejectedValue(
+      new ApiRequestError({ code: "not_found", message: "missing", context: {} }),
+    );
+    renderSetupPage("/setup");
+
+    await screen.findByRole("heading", { name: "First setup" });
+    await waitFor(() =>
+      expect(screen.getByLabelText("Working directory")).toHaveValue("/workspace"),
+    );
+
+    // The Next button stays disabled until the current section is complete, so
+    // fill in the required project description first.
+    await user.type(screen.getByLabelText("Project description"), "Demo project");
+    const nextButton = screen.getByRole("button", { name: t("setup.status.next") });
+    await waitFor(() => expect(nextButton).toBeEnabled());
+
+    await user.click(nextButton);
+    expect(await screen.findByText(t("setup.intelligence.defaultProvider"))).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: t("setup.status.back") }));
+    expect(await screen.findByLabelText("Working directory")).toBeInTheDocument();
+  });
+
+  it("creates the initial setup via initConfig and restartBackend", async () => {
+    const user = userEvent.setup();
+    Object.defineProperty(window, "__TAURI_INTERNALS__", { value: {}, configurable: true });
+    vi.mocked(getCliAgentDetections).mockResolvedValue({
+      agents: [
+        { name: "codex", executable: "codex", detected: true, path: "/usr/local/bin/codex" },
+      ],
+    });
+    vi.mocked(getConfigStatus).mockResolvedValue(
+      configStatus({ primary_project_file_exists: false, home_project_file_exists: false }),
+    );
+    vi.mocked(getTeam).mockRejectedValue(
+      new ApiRequestError({ code: "not_found", message: "missing", context: {} }),
+    );
+    renderSetupPage("/setup");
+
+    await screen.findByRole("heading", { name: "First setup" });
+
+    // Complete every required section so the Create action becomes available:
+    // project description, the provider API key, and a GitHub decision.
+    await waitFor(() =>
+      expect(screen.getByLabelText("Working directory")).toHaveValue("/workspace"),
+    );
+    await user.type(screen.getByLabelText("Project description"), "Demo project");
+    await user.click(screen.getByRole("button", { name: "LLM / CLI agent" }));
+    await user.type(await screen.findByLabelText("OpenAI API key"), "sk-test");
+    await user.click(screen.getByRole("button", { name: "GitHub" }));
+    await user.click(await screen.findByRole("textbox", { name: "GitHub integration" }));
+    await user.click(await screen.findByRole("option", { name: "Do not use GitHub" }));
+
+    // Add one active member so the members section is complete; the add form is
+    // shown by default and pre-filled with character defaults.
+    await user.click(screen.getByRole("button", { name: "Members" }));
+    await user.type(await screen.findByLabelText("Member ID"), "alice");
+    await user.type(screen.getByLabelText("Display name"), "Alice");
+    await user.click(screen.getByRole("button", { name: "Add member" }));
+
+    const createButton = await screen.findByRole("button", { name: t("setup.saveInitial") });
+    await user.click(createButton);
+
+    await waitFor(() => expect(initConfig).toHaveBeenCalledTimes(1));
+    // The init payload conveys "GitHub disabled" by leaving the owner /
+    // repository / project URL fields empty (there is no github_enabled flag).
+    expect(vi.mocked(initConfig).mock.calls[0][0]).toMatchObject({
+      description: "Demo project",
+      llm_api_type: "openai",
+      cli_agent: "codex",
+      owner: "",
+      repository_name: "",
+      github_project_url: "",
+      openai_api_key: "sk-test",
+    });
+    await waitFor(() => expect(restartBackend).toHaveBeenCalledWith("/workspace"));
+    expect(localStorage.getItem("guildbotics.workspace")).toBe("/workspace");
+    expect(await screen.findByText(t("setup.initialCreated.title"))).toBeInTheDocument();
+  });
+
+  it("autosaves an existing project through updateProjectConfig", async () => {
+    const user = userEvent.setup();
+    renderSetupPage("/setup");
+
+    const description = await screen.findByLabelText("Project description");
+    await waitFor(() => expect(description).toHaveValue("Demo project"));
+    await user.clear(description);
+    await user.type(description, "Updated description");
+
+    await waitFor(() => expect(updateProjectConfig).toHaveBeenCalledTimes(1), { timeout: 3000 });
+    expect(vi.mocked(updateProjectConfig).mock.calls[0][0]).toMatchObject({
+      description: "Updated description",
+    });
+    expect(initConfig).not.toHaveBeenCalled();
+  });
+
+  it("does not autosave when the form has a validation error", async () => {
+    const user = userEvent.setup();
+    renderSetupPage("/setup");
+
+    const description = await screen.findByLabelText("Project description");
+    await waitFor(() => expect(description).toHaveValue("Demo project"));
+    await user.clear(description);
+
+    await new Promise((resolve) => setTimeout(resolve, 1200));
+    expect(updateProjectConfig).not.toHaveBeenCalled();
   });
 });
 
@@ -183,3 +533,1657 @@ function configWriteResponse() {
     intelligence: null,
   };
 }
+
+type ProjectFormValues = Parameters<typeof toProjectSetupRequest>[0];
+type MemberFormValues = Parameters<typeof getMemberFieldErrors>[0];
+
+function baseProjectValues(overrides: Partial<ProjectFormValues> = {}): ProjectFormValues {
+  return {
+    workspaceDir: "/workspace",
+    configLocation: "workspace",
+    envFileOption: "append",
+    language: "en",
+    description: "Demo project",
+    llmApiType: "openai",
+    cliAgent: "codex",
+    googleApiKey: "",
+    openaiApiKey: "",
+    anthropicApiKey: "",
+    githubDecision: "disabled",
+    githubEnabled: false,
+    githubProjectUrl: "",
+    githubRepositoryUrl: "",
+    repoAccess: "https",
+    ...overrides,
+  };
+}
+
+function baseMemberValues(overrides: Partial<MemberFormValues> = {}): MemberFormValues {
+  return {
+    personType: "human",
+    identity: "",
+    personId: "alice",
+    personName: "Alice",
+    githubUsername: "alice",
+    gitEmail: "alice@example.com",
+    githubInstallationId: "",
+    githubAppId: "",
+    githubPrivateKeyPath: "",
+    githubAccessToken: "",
+    slackBotToken: "",
+    slackAppToken: "",
+    slackChannelsText: "",
+    storedMemberSecrets: {
+      githubInstallationId: false,
+      githubAppId: false,
+      githubPrivateKeyPath: false,
+      githubAccessToken: false,
+      slackBotToken: false,
+      slackAppToken: false,
+    },
+    roles: ["professional"],
+    speakingStyle: "Professional",
+    characterArchetype: "manager",
+    characterTraits: ["organized"],
+    characterInterests: ["planning"],
+    characterJoinWhenText: "When planning is needed",
+    characterAvoidWhenText: "When chatting",
+    characterContributionText: "Clarify next actions",
+    existingPersonIds: [],
+    originalPersonId: null,
+    ...overrides,
+  };
+}
+
+function configStatus(overrides: Record<string, unknown> = {}): ConfigStatus {
+  return {
+    cwd: "/workspace",
+    env_file: "/workspace/.env",
+    env_file_exists: true,
+    primary_config_dir: "/workspace/.guildbotics/config",
+    primary_config_location: "workspace",
+    primary_project_file: "/workspace/.guildbotics/config/project.yml",
+    primary_project_file_exists: false,
+    home_config_dir: "/home/.guildbotics/config",
+    home_project_file: "/home/.guildbotics/config/project.yml",
+    home_project_file_exists: false,
+    active_config_dir: "/workspace/.guildbotics/config",
+    active_config_location: "workspace",
+    storage_dir: "/workspace/.guildbotics",
+    ...overrides,
+  } as ConfigStatus;
+}
+
+type ProjectConfigValue = Parameters<typeof toProjectUpdateRequest>[2];
+
+function projectConfig(overrides: Record<string, unknown> = {}): ProjectConfigValue {
+  return {
+    config_dir: "/workspace/.guildbotics/config",
+    env_file_path: "/workspace/.env",
+    language: "en",
+    description: "Existing project",
+    llm_api_type: "openai",
+    cli_agent: "codex",
+    github_enabled: false,
+    github_project_url: "",
+    github_repository_url: "",
+    repo_base_url: "https://github.com",
+    has_google_api_key: false,
+    has_openai_api_key: true,
+    has_anthropic_api_key: false,
+    ...overrides,
+  } as ProjectConfigValue;
+}
+
+function commandOption(overrides: Partial<CommandOption> = {}): CommandOption {
+  return {
+    command: "workflows/ticket_driven_workflow",
+    label: "Ticket workflow",
+    description: "",
+    category: "workflow",
+    source: "template",
+    path: "workflows/ticket_driven_workflow.md",
+    arguments: [],
+    supports_raw_args: true,
+    recommended_input: "",
+    requirements: [],
+    ...overrides,
+  };
+}
+
+function firstError(
+  result: ReturnType<ReturnType<typeof createProjectSchema>["safeParse"]>,
+  path: string,
+) {
+  if (result.success) {
+    return undefined;
+  }
+  return result.error.issues.find((issue) => issue.path.join(".") === path)?.message;
+}
+
+describe("createProjectSchema", () => {
+  const schema = createProjectSchema(t);
+
+  it("requires a workspace directory", () => {
+    const result = schema.safeParse(baseProjectValues({ workspaceDir: "" }));
+    expect(firstError(result, "workspaceDir")).toBe(t("setup.validation.workspaceRequired"));
+  });
+
+  it("requires a project description", () => {
+    const result = schema.safeParse(baseProjectValues({ description: "   " }));
+    expect(firstError(result, "description")).toBe(t("setup.validation.descriptionRequired"));
+  });
+
+  it("requires a GitHub decision", () => {
+    const result = schema.safeParse(baseProjectValues({ githubDecision: "" }));
+    expect(firstError(result, "githubDecision")).toBe(t("setup.validation.githubDecisionRequired"));
+  });
+
+  it("does not validate GitHub URLs when GitHub is disabled", () => {
+    const result = schema.safeParse(
+      baseProjectValues({
+        githubDecision: "disabled",
+        githubProjectUrl: "",
+        githubRepositoryUrl: "",
+      }),
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("validates GitHub project and repository URLs when enabled", () => {
+    const result = schema.safeParse(
+      baseProjectValues({
+        githubDecision: "enabled",
+        githubProjectUrl: "not-a-url",
+        githubRepositoryUrl: "",
+      }),
+    );
+    expect(firstError(result, "githubProjectUrl")).toBe(t("setup.validation.githubProjectInvalid"));
+    expect(firstError(result, "githubRepositoryUrl")).toBe(
+      t("setup.validation.githubRepositoryRequired"),
+    );
+  });
+
+  it("flags repository owner / project owner mismatch", () => {
+    const result = schema.safeParse(
+      baseProjectValues({
+        githubDecision: "enabled",
+        githubProjectUrl: "https://github.com/orgs/acme/projects/7",
+        githubRepositoryUrl: "https://github.com/other/repo",
+      }),
+    );
+    expect(firstError(result, "githubRepositoryUrl")).toBe(
+      t("setup.validation.githubRepositoryOwnerMismatch"),
+    );
+  });
+
+  it("accepts a fully valid GitHub-enabled project", () => {
+    const result = schema.safeParse(
+      baseProjectValues({
+        githubDecision: "enabled",
+        githubProjectUrl: "https://github.com/orgs/acme/projects/7",
+        githubRepositoryUrl: "https://github.com/acme/repo",
+      }),
+    );
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("parseGitHub", () => {
+  it("parses an organization project URL", () => {
+    const parsed = parseGitHub(
+      "https://github.com/orgs/acme/projects/12",
+      "https://github.com/acme/repo",
+    );
+    expect(parsed).toMatchObject({
+      owner: "acme",
+      projectId: "12",
+      repositoryName: "repo",
+      projectUrl: "https://github.com/orgs/acme/projects/12",
+      projectValid: true,
+      repositoryValid: true,
+      ownerConsistent: true,
+    });
+  });
+
+  it("parses a user project URL", () => {
+    const parsed = parseGitHub(
+      "https://github.com/users/alice/projects/3?query=1",
+      "https://github.com/alice/repo",
+    );
+    expect(parsed.owner).toBe("alice");
+    expect(parsed.projectId).toBe("3");
+    expect(parsed.projectUrl).toBe("https://github.com/users/alice/projects/3");
+    expect(parsed.ownerConsistent).toBe(true);
+  });
+
+  it("invalidates non-github project URLs", () => {
+    const parsed = parseGitHub("https://example.com/orgs/acme/projects/1", "");
+    expect(parsed.projectValid).toBe(false);
+    expect(parsed.owner).toBe("");
+    expect(parsed.projectId).toBe("");
+  });
+
+  it("does not return a repository name when owners differ", () => {
+    const parsed = parseGitHub(
+      "https://github.com/orgs/acme/projects/12",
+      "https://github.com/other/repo",
+    );
+    expect(parsed.repositoryValid).toBe(true);
+    expect(parsed.ownerConsistent).toBe(false);
+    expect(parsed.repositoryName).toBe("");
+  });
+});
+
+describe("initialProjectValues", () => {
+  it("returns defaults when no config exists", () => {
+    localStorage.clear();
+    const values = initialProjectValues(undefined, "ja", null, undefined);
+    expect(values).toMatchObject({
+      workspaceDir: "",
+      configLocation: "home",
+      envFileOption: "overwrite",
+      language: "ja",
+      description: "",
+      llmApiType: "openai",
+      cliAgent: "codex",
+      githubDecision: "",
+      githubEnabled: false,
+      repoAccess: "https",
+    });
+  });
+
+  it("derives workspace config location and append option from config status", () => {
+    const values = initialProjectValues(
+      configStatus({ primary_config_location: "workspace", env_file_exists: true }),
+      "en",
+      null,
+      undefined,
+    );
+    expect(values.workspaceDir).toBe("/workspace");
+    expect(values.configLocation).toBe("workspace");
+    expect(values.envFileOption).toBe("append");
+  });
+
+  it("maps home config location and overwrite option", () => {
+    const values = initialProjectValues(
+      configStatus({ primary_config_location: "home", env_file_exists: false }),
+      "en",
+      null,
+      undefined,
+    );
+    expect(values.configLocation).toBe("home");
+    expect(values.envFileOption).toBe("overwrite");
+  });
+
+  it("treats custom config location as home", () => {
+    const values = initialProjectValues(
+      configStatus({ primary_config_location: "custom" }),
+      "en",
+      null,
+      undefined,
+    );
+    expect(values.configLocation).toBe("home");
+  });
+
+  it("uses the project language when the primary project file exists", () => {
+    const values = initialProjectValues(
+      configStatus({ primary_project_file_exists: true }),
+      "en",
+      "ja",
+      undefined,
+    );
+    expect(values.language).toBe("ja");
+  });
+
+  it("hydrates from an existing project config without exposing API keys", () => {
+    const values = initialProjectValues(
+      configStatus({ active_config_location: "workspace" }),
+      "en",
+      null,
+      projectConfig({
+        language: "ja",
+        description: "Existing",
+        github_enabled: true,
+        github_project_url: "https://github.com/orgs/acme/projects/1",
+        github_repository_url: "https://github.com/acme/repo",
+        repo_base_url: "ssh://git@github.com",
+      }),
+    );
+    expect(values.language).toBe("ja");
+    expect(values.description).toBe("Existing");
+    expect(values.githubDecision).toBe("enabled");
+    expect(values.githubEnabled).toBe(true);
+    expect(values.repoAccess).toBe("ssh");
+    expect(values.googleApiKey).toBe("");
+    expect(values.openaiApiKey).toBe("");
+    expect(values.anthropicApiKey).toBe("");
+  });
+});
+
+describe("toProjectSetupRequest", () => {
+  it("honors the env file option override and omits GitHub fields when disabled", () => {
+    const request = toProjectSetupRequest(
+      baseProjectValues({ githubDecision: "disabled" }),
+      configStatus(),
+      { envFileOption: "overwrite" },
+    );
+    expect(request.env_file_option).toBe("overwrite");
+    expect(request.env_file_path).toBe("/workspace/.env");
+    expect(request.config_dir).toBe("/workspace/.guildbotics/config");
+    expect(request.owner).toBe("");
+    expect(request.repository_name).toBe("");
+    expect(request.project_id).toBe("");
+    expect(request.github_project_url).toBe("");
+    expect(request.repo_base_url).toBe("https://github.com");
+  });
+
+  it("populates GitHub fields and ssh repo access when enabled", () => {
+    const request = toProjectSetupRequest(
+      baseProjectValues({
+        githubDecision: "enabled",
+        githubProjectUrl: "https://github.com/orgs/acme/projects/9",
+        githubRepositoryUrl: "https://github.com/acme/repo",
+        repoAccess: "ssh",
+      }),
+      configStatus(),
+    );
+    expect(request.owner).toBe("acme");
+    expect(request.project_id).toBe("9");
+    expect(request.repository_name).toBe("repo");
+    expect(request.github_project_url).toBe("https://github.com/orgs/acme/projects/9");
+    expect(request.repo_base_url).toBe("ssh://git@github.com");
+  });
+
+  it("uses the home config dir when home location is selected", () => {
+    const request = toProjectSetupRequest(
+      baseProjectValues({ configLocation: "home" }),
+      configStatus({ home_config_dir: "/home/.guildbotics/config" }),
+    );
+    expect(request.config_dir).toBe("/home/.guildbotics/config");
+  });
+});
+
+describe("toProjectUpdateRequest", () => {
+  const snapshot = projectConfig();
+
+  it("omits empty API keys so existing secrets are preserved", () => {
+    const request = toProjectUpdateRequest(
+      baseProjectValues({ openaiApiKey: "", googleApiKey: "", anthropicApiKey: "" }),
+      configStatus(),
+      snapshot,
+    );
+    expect(request.openai_api_key).toBeUndefined();
+    expect(request.google_api_key).toBeUndefined();
+    expect(request.anthropic_api_key).toBeUndefined();
+  });
+
+  it("forwards non-empty API keys", () => {
+    const request = toProjectUpdateRequest(
+      baseProjectValues({ openaiApiKey: "sk-new" }),
+      configStatus(),
+      snapshot,
+    );
+    expect(request.openai_api_key).toBe("sk-new");
+  });
+
+  it("disables GitHub and clears related fields", () => {
+    const request = toProjectUpdateRequest(
+      baseProjectValues({ githubDecision: "disabled", repoAccess: "ssh" }),
+      configStatus(),
+      snapshot,
+    );
+    expect(request.github_enabled).toBe(false);
+    expect(request.owner).toBe("");
+    expect(request.repository_name).toBe("");
+    expect(request.repo_base_url).toBe("ssh://git@github.com");
+  });
+
+  it("enables GitHub and converts https repo access", () => {
+    const request = toProjectUpdateRequest(
+      baseProjectValues({
+        githubDecision: "enabled",
+        githubProjectUrl: "https://github.com/orgs/acme/projects/5",
+        githubRepositoryUrl: "https://github.com/acme/repo",
+        repoAccess: "https",
+      }),
+      configStatus(),
+      snapshot,
+    );
+    expect(request.github_enabled).toBe(true);
+    expect(request.owner).toBe("acme");
+    expect(request.project_id).toBe("5");
+    expect(request.repo_base_url).toBe("https://github.com");
+  });
+});
+
+describe("getMemberFieldErrors", () => {
+  it("returns no errors for a valid human member without GitHub auth", () => {
+    const errors = getMemberFieldErrors(baseMemberValues({ personType: "human" }), t);
+    expect(errors).toEqual({});
+  });
+
+  it("flags missing core member fields", () => {
+    const errors = getMemberFieldErrors(
+      baseMemberValues({
+        personType: "",
+        personId: "",
+        personName: "",
+        githubUsername: "",
+        gitEmail: "",
+        roles: [],
+        speakingStyle: "",
+        characterArchetype: "",
+        characterTraits: [],
+        characterInterests: [],
+        characterJoinWhenText: "",
+        characterAvoidWhenText: "",
+        characterContributionText: "",
+      }),
+      t,
+    );
+    expect(errors.personId).toBe(t("setup.validation.memberIdRequired"));
+    expect(errors.personName).toBe(t("setup.validation.memberNameRequired"));
+    expect(errors.roles).toBe(t("setup.validation.memberRolesRequired"));
+    expect(errors.speakingStyle).toBe(t("setup.validation.memberSpeakingStyleRequired"));
+    expect(errors.characterArchetype).toBe(t("setup.validation.memberCharacterArchetypeRequired"));
+    expect(errors.characterTraits).toBe(t("setup.validation.memberCharacterTraitsRequired"));
+    expect(errors.characterInterests).toBe(t("setup.validation.memberCharacterInterestsRequired"));
+    expect(errors.characterJoinWhenText).toBe(
+      t("setup.validation.memberCharacterJoinWhenRequired"),
+    );
+    expect(errors.characterAvoidWhenText).toBe(
+      t("setup.validation.memberCharacterAvoidWhenRequired"),
+    );
+    expect(errors.characterContributionText).toBe(
+      t("setup.validation.memberCharacterContributionRequired"),
+    );
+  });
+
+  it("rejects invalid and duplicate member ids", () => {
+    expect(getMemberFieldErrors(baseMemberValues({ personId: "Has Space" }), t).personId).toBe(
+      t("setup.validation.memberIdInvalid"),
+    );
+    expect(
+      getMemberFieldErrors(
+        baseMemberValues({
+          personId: "bob",
+          existingPersonIds: ["bob"],
+          originalPersonId: "alice",
+        }),
+        t,
+      ).personId,
+    ).toBe(t("setup.validation.memberIdDuplicate"));
+  });
+
+  it("requires an access token for machine_user and proxy_agent members", () => {
+    for (const personType of ["machine_user", "proxy_agent"] as const) {
+      const errors = getMemberFieldErrors(
+        baseMemberValues({ personType, githubAccessToken: "" }),
+        t,
+      );
+      expect(errors.githubAccessToken).toBe(t("setup.validation.githubAccessTokenRequired"));
+    }
+  });
+
+  it("accepts a stored access token for machine_user members", () => {
+    const errors = getMemberFieldErrors(
+      baseMemberValues({
+        personType: "machine_user",
+        githubAccessToken: "",
+        storedMemberSecrets: {
+          githubInstallationId: false,
+          githubAppId: false,
+          githubPrivateKeyPath: false,
+          githubAccessToken: true,
+          slackBotToken: false,
+          slackAppToken: false,
+        },
+      }),
+      t,
+    );
+    expect(errors.githubAccessToken).toBeUndefined();
+  });
+
+  it("validates the format of a provided access token", () => {
+    const errors = getMemberFieldErrors(
+      baseMemberValues({ personType: "machine_user", githubAccessToken: "bad-token" }),
+      t,
+    );
+    expect(errors.githubAccessToken).toBe(t("setup.validation.githubAccessTokenInvalid"));
+  });
+
+  it("requires installation id, app id, and private key path for github_apps", () => {
+    const errors = getMemberFieldErrors(
+      baseMemberValues({
+        personType: "github_apps",
+        identity: "https://github.com/organizations/acme/settings/apps/my-app",
+        githubInstallationId: "",
+        githubAppId: "",
+        githubPrivateKeyPath: "",
+      }),
+      t,
+    );
+    expect(errors.githubInstallationId).toBe(t("setup.validation.githubInstallationIdRequired"));
+    expect(errors.githubAppId).toBe(t("setup.validation.githubAppIdRequired"));
+    expect(errors.githubPrivateKeyPath).toBe(t("setup.validation.githubPrivateKeyPathRequired"));
+  });
+
+  it("validates Slack channels, bot token, and app token", () => {
+    const errors = getMemberFieldErrors(
+      baseMemberValues({
+        slackChannelsText: "general, BAD CHANNEL",
+        slackBotToken: "not-a-bot-token",
+        slackAppToken: "not-an-app-token",
+      }),
+      t,
+    );
+    expect(errors.slackChannelsText).toBe(t("setup.validation.slackChannelsInvalid"));
+    expect(errors.slackBotToken).toBe(t("setup.validation.slackBotTokenInvalid"));
+    expect(errors.slackAppToken).toBe(t("setup.validation.slackAppTokenInvalid"));
+  });
+
+  it("requires Slack tokens when channels are configured", () => {
+    const errors = getMemberFieldErrors(baseMemberValues({ slackChannelsText: "general" }), t);
+    expect(errors.slackBotToken).toBe(t("setup.validation.slackBotTokenRequired"));
+    expect(errors.slackAppToken).toBe(t("setup.validation.slackAppTokenRequired"));
+  });
+});
+
+describe("getMemberResolveErrorMessage", () => {
+  it("maps known GitHub identity API error codes", () => {
+    for (const code of ["invalid_github_username", "invalid_github_apps_url"]) {
+      const error = new ApiRequestError({ code, message: "boom", context: {} });
+      expect(getMemberResolveErrorMessage(error, t)).toBe(
+        t("setup.validation.memberGithubIdentityNotFound"),
+      );
+    }
+  });
+
+  it("falls back to the generic resolve failure for unknown errors", () => {
+    expect(getMemberResolveErrorMessage(new Error("network"), t)).toBe(
+      t("setup.validation.memberGithubIdentityResolveFailed"),
+    );
+    const otherApiError = new ApiRequestError({ code: "rate_limited", message: "x", context: {} });
+    expect(getMemberResolveErrorMessage(otherApiError, t)).toBe(
+      t("setup.validation.memberGithubIdentityResolveFailed"),
+    );
+  });
+});
+
+describe("character payload round trip", () => {
+  it("parses list fields and preserves extra character fields", () => {
+    const parsed = parseCharacterFields({
+      archetype: "manager",
+      traits: [" organized ", "", "strategic"],
+      interests: ["planning"],
+      conversation_preferences: {
+        join_when: ["When planning"],
+        avoid_when: ["When chatting"],
+        contribution_style: ["Clarify"],
+        custom_pref: "keep me",
+      },
+      extra_top_level: { nested: true },
+    });
+    expect(parsed.archetype).toBe("manager");
+    expect(parsed.traits).toEqual(["organized", "strategic"]);
+    expect(parsed.joinWhen).toEqual(["When planning"]);
+    expect(parsed.extras).toEqual({
+      extra_top_level: { nested: true },
+      conversation_preferences: { custom_pref: "keep me" },
+    });
+  });
+
+  it("handles a malformed character object gracefully", () => {
+    const parsed = parseCharacterFields({
+      traits: "not-a-list" as unknown as string[],
+      conversation_preferences: 42 as unknown as Record<string, unknown>,
+    });
+    expect(parsed.archetype).toBe("");
+    expect(parsed.traits).toEqual([]);
+    expect(parsed.joinWhen).toEqual([]);
+  });
+
+  it("rebuilds a payload that preserves extras and drops empty lists", () => {
+    const parsed = parseCharacterFields({
+      archetype: "manager",
+      traits: ["organized"],
+      interests: ["planning"],
+      conversation_preferences: {
+        join_when: ["When planning"],
+        custom_pref: "keep me",
+      },
+      extra_top_level: "x",
+    });
+    const payload = buildCharacterPayload({ ...parsed, avoidWhen: [], contributionStyle: [] });
+    expect(payload.archetype).toBe("manager");
+    expect(payload.traits).toEqual(["organized"]);
+    expect(payload.extra_top_level).toBe("x");
+    expect(payload.conversation_preferences).toEqual({
+      custom_pref: "keep me",
+      join_when: ["When planning"],
+    });
+  });
+});
+
+describe("toIntelligenceUpdatePayload", () => {
+  const team = {
+    config_dir: "/workspace/.guildbotics/config",
+    person_id: null,
+    inherited: false,
+    model_mapping: { default: "models/openai.yml" },
+    models: [
+      {
+        path: "models/openai.yml",
+        provider: "openai",
+        model_class: "OpenAIModel",
+        model_id: "gpt-5",
+      },
+    ],
+    cli_agent_mapping: { default: "codex-cli.yml" },
+    cli_agents: [
+      {
+        path: "codex-cli.yml",
+        name: "codex" as const,
+        env: {},
+        script: "codex",
+        detected: true,
+        detected_path: "/usr/local/bin/codex",
+      },
+    ],
+    brain_mapping: [],
+  };
+
+  it("emits a full team-default update", () => {
+    const payload = toIntelligenceUpdatePayload(team);
+    expect(payload).toMatchObject({
+      person_id: null,
+      inherit_team_defaults: false,
+      model_mapping: team.model_mapping,
+      models: team.models,
+      cli_agents: team.cli_agents,
+      brain_mapping: team.brain_mapping,
+    });
+  });
+
+  it("emits a member override update without full definitions", () => {
+    const payload = toIntelligenceUpdatePayload({ ...team, person_id: "alice", inherited: false });
+    expect(payload).toEqual({
+      config_dir: team.config_dir,
+      person_id: "alice",
+      inherit_team_defaults: false,
+      model_mapping: team.model_mapping,
+      cli_agent_mapping: team.cli_agent_mapping,
+    });
+    expect("models" in payload).toBe(false);
+  });
+
+  it("emits an inherit-team-defaults update", () => {
+    const payload = toIntelligenceUpdatePayload({ ...team, person_id: "alice", inherited: true });
+    expect(payload).toEqual({
+      config_dir: team.config_dir,
+      person_id: "alice",
+      inherit_team_defaults: true,
+    });
+  });
+
+  it("substitutes person_id via savePersonId", () => {
+    const payload = toIntelligenceUpdatePayload(team, "bob");
+    expect(payload.person_id).toBe("bob");
+  });
+});
+
+describe("patrol / schedule helpers", () => {
+  it("creates a catalog draft when a command is supplied", () => {
+    const draft = createScheduledCommandDraft("workflows/ticket_driven_workflow");
+    expect(draft.commandMode).toBe("catalog");
+    expect(draft.command).toBe("workflows/ticket_driven_workflow");
+    expect(draft.scheduleMode).toBe("daily");
+    expect(draft.cron).toBe("0 9 * * *");
+  });
+
+  it("creates a custom draft when no command is supplied", () => {
+    expect(createScheduledCommandDraft().commandMode).toBe("custom");
+  });
+
+  it("converts schedule presets to cron expressions", () => {
+    const base = createScheduledCommandDraft("cmd");
+    expect(draftToCron({ ...base, scheduleMode: "hourly", minute: 15 })).toBe("15 * * * *");
+    expect(draftToCron({ ...base, scheduleMode: "daily", minute: 30, hour: 8 })).toBe("30 8 * * *");
+    expect(draftToCron({ ...base, scheduleMode: "weekly", minute: 0, hour: 9, weekday: "3" })).toBe(
+      "0 9 * * 3",
+    );
+    expect(draftToCron({ ...base, scheduleMode: "custom", cron: " */5 * * * * " })).toBe(
+      "*/5 * * * *",
+    );
+  });
+
+  it("clamps out-of-range minute and hour values", () => {
+    const base = createScheduledCommandDraft("cmd");
+    expect(draftToCron({ ...base, scheduleMode: "daily", minute: 99, hour: 99 })).toBe(
+      "59 23 * * *",
+    );
+  });
+
+  it("parses cron expressions back into preset drafts", () => {
+    expect(parseCron("15 * * * *")).toEqual({
+      mode: "hourly",
+      minute: 15,
+      hour: 9,
+      weekday: "1",
+    });
+    expect(parseCron("30 8 * * *")).toEqual({
+      mode: "daily",
+      minute: 30,
+      hour: 8,
+      weekday: "1",
+    });
+    expect(parseCron("0 9 * * 3")).toEqual({
+      mode: "weekly",
+      minute: 0,
+      hour: 9,
+      weekday: "3",
+    });
+    expect(parseCron("0 9 1 * *").mode).toBe("custom");
+    expect(parseCron("not valid").mode).toBe("custom");
+  });
+
+  it("validates cron field count", () => {
+    expect(isValidCron("0 9 * * *")).toBe(true);
+    expect(isValidCron("  0   9 * * *  ")).toBe(true);
+    expect(isValidCron("0 9 * *")).toBe(false);
+  });
+
+  it("splits and quotes command-line arguments", () => {
+    expect(splitCommandLine('foo "bar baz" qux')).toEqual(["foo", "bar baz", "qux"]);
+    expect(splitCommandLine("a   b")).toEqual(["a", "b"]);
+    expect(quoteCommandArg("simple")).toBe("simple");
+    expect(quoteCommandArg("has space")).toBe('"has space"');
+    expect(quoteCommandArg('quote"and\\slash here')).toBe('"quote\\"and\\\\slash here"');
+  });
+
+  it("builds a scheduled command expression with catalog args and raw args", () => {
+    const option = commandOption({
+      command: "report",
+      arguments: [
+        { name: "target", kind: "positional", required: true, default: "" },
+        { name: "--format", kind: "keyword", required: false, default: "" },
+      ],
+    });
+    const draft: ScheduledCommandDraft = {
+      ...createScheduledCommandDraft("report"),
+      argValues: { target: "weekly report", "--format": "pdf" },
+      rawArgs: "--verbose",
+    };
+    const expression = buildScheduledCommandExpression(draft, new Map([[option.command, option]]));
+    expect(expression).toBe('report "weekly report" --format=pdf --verbose');
+  });
+
+  it("uses the trimmed custom command for custom mode", () => {
+    const draft: ScheduledCommandDraft = {
+      ...createScheduledCommandDraft(),
+      commandMode: "custom",
+      customCommand: "  my/custom_command  ",
+    };
+    expect(buildScheduledCommandExpression(draft, new Map())).toBe("my/custom_command");
+  });
+
+  it("groups task schedules by command and skips invalid drafts", () => {
+    const drafts: ScheduledCommandDraft[] = [
+      { ...createScheduledCommandDraft("alpha"), scheduleMode: "daily", minute: 0, hour: 9 },
+      { ...createScheduledCommandDraft("alpha"), scheduleMode: "hourly", minute: 30 },
+      {
+        ...createScheduledCommandDraft(),
+        commandMode: "custom",
+        customCommand: "",
+        scheduleMode: "daily",
+      },
+    ];
+    const schedules = buildTaskSchedules(drafts, new Map());
+    expect(schedules).toEqual([{ command: "alpha", schedules: ["0 9 * * *", "30 * * * *"] }]);
+  });
+
+  it("parses catalog commands and falls back to custom commands", () => {
+    const catalog = [
+      commandOption({ command: "report" }),
+      commandOption({ command: "report/weekly" }),
+    ];
+    const matched = parseCommandExpression("report/weekly arg1 arg2", catalog);
+    expect(matched.option?.command).toBe("report/weekly");
+    expect(matched.command).toBe("report/weekly");
+    expect(matched.args).toBe("arg1 arg2");
+
+    const custom = parseCommandExpression('my/cmd "a b" c', catalog);
+    expect(custom.option).toBeNull();
+    expect(custom.command).toBe("my/cmd");
+    expect(custom.args).toBe("a b c");
+  });
+
+  it("round trips a catalog command through expression and parse", () => {
+    const option = commandOption({ command: "report" });
+    const draft: ScheduledCommandDraft = {
+      ...createScheduledCommandDraft("report"),
+      rawArgs: "alpha beta",
+    };
+    const expression = buildScheduledCommandExpression(draft, new Map([[option.command, option]]));
+    const parsed = parseCommandExpression(expression, [option]);
+    expect(parsed.option?.command).toBe("report");
+    expect(parsed.args).toBe("alpha beta");
+  });
+});
+
+function memberConfigDetail(overrides: Partial<MemberConfig> = {}): MemberConfig {
+  return {
+    person_id: "alice",
+    person_name: "Alice",
+    // No GitHub linking keeps the loaded member valid for save without extra
+    // GitHub identity fields.
+    person_type: "",
+    is_active: true,
+    github_username: "",
+    git_email: "",
+    roles: ["professional"],
+    speaking_style: "Professional and concise",
+    relationships: "",
+    character: {
+      archetype: "manager",
+      traits: ["organized"],
+      interests: ["planning"],
+      conversation_preferences: {
+        join_when: ["When planning is needed"],
+        avoid_when: ["When chatting"],
+        contribution_style: ["Clarify next actions"],
+      },
+    },
+    github_installation_id: null,
+    github_app_id: null,
+    github_private_key_path: "",
+    has_github_installation_id: false,
+    has_github_app_id: false,
+    has_github_private_key_path: false,
+    has_github_access_token: false,
+    has_slack_bot_token: false,
+    has_slack_app_token: false,
+    slack_channels: [],
+    routine_commands: [],
+    task_schedules: [],
+    ...overrides,
+  };
+}
+
+// Fill the required Basic-tab fields so the member form can be submitted; the
+// add form is pre-populated with the "professional" preset, so only the member
+// id and display name are missing for a human member.
+async function fillRequiredMemberBasics(
+  user: ReturnType<typeof userEvent.setup>,
+  { personId = "bob", personName = "Bob" }: { personId?: string; personName?: string } = {},
+) {
+  await user.type(await screen.findByLabelText("Member ID"), personId);
+  await user.type(screen.getByLabelText("Display name"), personName);
+}
+
+function lastMemberAddRequest() {
+  const calls = vi.mocked(addMemberConfig).mock.calls;
+  return calls[calls.length - 1][0];
+}
+
+describe("MembersSection", () => {
+  it("shows the add form when there are no members", async () => {
+    vi.mocked(getTeam).mockResolvedValue({
+      project: { name: "Demo", language_code: "en", language_name: "English" },
+      members: [],
+    });
+    renderSetupPage("/setup?section=members");
+
+    expect(await screen.findByText(t("setup.members.requiredTitle"))).toBeInTheDocument();
+    expect(await screen.findByLabelText("Member ID")).toBeInTheDocument();
+    // The form header ("Add member") and the submit button share the same text;
+    // assert on the submit button explicitly.
+    expect(screen.getByRole("button", { name: t("setup.members.addButton") })).toBeInTheDocument();
+    // With no members configured there is no "Add new member" toggle button.
+    expect(
+      screen.queryByRole("button", { name: t("setup.members.newButton") }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("adds a member through addMemberConfig with the built payload", async () => {
+    const user = userEvent.setup();
+    vi.mocked(getTeam).mockResolvedValue({
+      project: { name: "Demo", language_code: "en", language_name: "English" },
+      members: [],
+    });
+    renderSetupPage("/setup?section=members");
+
+    await fillRequiredMemberBasics(user, { personId: "bob", personName: "Bob" });
+    await user.click(screen.getByRole("button", { name: t("setup.members.addButton") }));
+
+    await waitFor(() => expect(addMemberConfig).toHaveBeenCalledTimes(1));
+    const request = lastMemberAddRequest();
+    expect(request).toMatchObject({
+      person_id: "bob",
+      person_name: "Bob",
+      // The default add form leaves GitHub linking unset (person_type "").
+      person_type: "",
+      is_active: true,
+      roles: ["professional"],
+      config_dir: "/workspace/.guildbotics/config",
+      env_file_path: "/workspace/.env",
+    });
+    // A member without GitHub linking sends no GitHub credentials.
+    expect(request.github_username).toBe("");
+    expect(request.github_access_token).toBeUndefined();
+    expect(request.github_installation_id).toBeUndefined();
+  });
+
+  it("edits a persisted member and submits an update payload", async () => {
+    const user = userEvent.setup();
+    vi.mocked(getMemberConfig).mockResolvedValue(memberConfigDetail({ person_name: "Alice" }));
+    renderSetupPage("/setup?section=members");
+
+    await user.click(await screen.findByRole("button", { name: t("setup.members.editButton") }));
+    expect(await screen.findByText(t("setup.members.editingBadge", { id: "alice" })));
+    await waitFor(() => expect(vi.mocked(getMemberConfig).mock.calls[0]?.[0]).toBe("alice"));
+
+    const nameInput = await screen.findByLabelText("Display name");
+    await waitFor(() => expect(nameInput).toHaveValue("Alice"));
+    await user.clear(nameInput);
+    await user.type(nameInput, "Alice Cooper");
+    await user.click(screen.getByRole("button", { name: t("setup.members.saveButton") }));
+
+    await waitFor(() => expect(updateMemberConfig).toHaveBeenCalledTimes(1));
+    const [personId, body] = vi.mocked(updateMemberConfig).mock.calls[0];
+    expect(personId).toBe("alice");
+    expect(body).toMatchObject({
+      original_person_id: "alice",
+      person_id: "alice",
+      person_name: "Alice Cooper",
+    });
+  });
+
+  it("deletes a member after confirming in the modal", async () => {
+    const user = userEvent.setup();
+    vi.mocked(getMemberConfig).mockResolvedValue(memberConfigDetail());
+    renderSetupPage("/setup?section=members");
+
+    await user.click(await screen.findByRole("button", { name: t("setup.members.editButton") }));
+    await waitFor(() => expect(vi.mocked(getMemberConfig).mock.calls[0]?.[0]).toBe("alice"));
+
+    // The footer Delete button opens the confirmation modal; the modal's own
+    // Delete button performs the deletion.
+    await user.click(await screen.findByRole("button", { name: t("setup.members.deleteButton") }));
+    expect(await screen.findByText(t("setup.members.deleteConfirmTitle"))).toBeInTheDocument();
+    const confirmButtons = screen.getAllByRole("button", { name: t("setup.members.deleteButton") });
+    await user.click(confirmButtons[confirmButtons.length - 1]);
+
+    await waitFor(() => expect(deleteMemberConfig).toHaveBeenCalledTimes(1));
+    expect(vi.mocked(deleteMemberConfig).mock.calls[0]).toEqual([
+      "alice",
+      { config_dir: "/workspace/.guildbotics/config", env_file_path: "/workspace/.env" },
+    ]);
+  });
+
+  it("keeps added members as drafts before the project is persisted", async () => {
+    const user = userEvent.setup();
+    vi.mocked(getConfigStatus).mockResolvedValue(
+      configStatus({ primary_project_file_exists: false, home_project_file_exists: false }),
+    );
+    vi.mocked(getTeam).mockRejectedValue(
+      new ApiRequestError({ code: "not_found", message: "missing", context: {} }),
+    );
+    renderSetupPage("/setup?section=members");
+
+    await fillRequiredMemberBasics(user, { personId: "carol", personName: "Carol" });
+    await user.click(screen.getByRole("button", { name: t("setup.members.addButton") }));
+
+    await waitFor(() => expect(addMemberConfig).toHaveBeenCalledTimes(1));
+    // In draft (not yet persisted) mode the member appears in the list without a
+    // backend reload, and getMemberConfig is never queried.
+    expect(await screen.findByText("Carol (carol)")).toBeInTheDocument();
+    expect(getMemberConfig).not.toHaveBeenCalled();
+  });
+
+  it("resolves a GitHub identity and fills username and email", async () => {
+    const user = userEvent.setup();
+    vi.mocked(getTeam).mockResolvedValue({
+      project: { name: "Demo", language_code: "en", language_name: "English" },
+      members: [],
+    });
+    vi.mocked(resolveMemberIdentity).mockResolvedValue({
+      person_id: "octo",
+      github_username: "octocat",
+      github_user_id: 42,
+      git_email: "octo@example.com",
+    });
+    renderSetupPage("/setup?section=members");
+
+    await screen.findByLabelText("Member ID");
+    await user.click(screen.getByRole("tab", { name: t("setup.members.tabs.github") }));
+
+    await selectMemberType(user, "Machine Account (Machine User)");
+    const usernameField = await screen.findByLabelText(t("setup.members.githubUsername"));
+    await user.type(usernameField, "octocat");
+    await user.click(screen.getByRole("button", { name: t("setup.members.resolve") }));
+
+    await waitFor(() => expect(resolveMemberIdentity).toHaveBeenCalled());
+    expect(vi.mocked(resolveMemberIdentity).mock.calls[0][0]).toEqual({
+      person_type: "machine_user",
+      identity: "octocat",
+    });
+    expect(await screen.findByLabelText(t("setup.members.gitEmail"))).toHaveValue(
+      "octo@example.com",
+    );
+  });
+
+  it("shows the resolve failure message for unknown GitHub usernames", async () => {
+    const user = userEvent.setup();
+    vi.mocked(getTeam).mockResolvedValue({
+      project: { name: "Demo", language_code: "en", language_name: "English" },
+      members: [],
+    });
+    vi.mocked(resolveMemberIdentity).mockRejectedValue(
+      new ApiRequestError({ code: "invalid_github_username", message: "nope", context: {} }),
+    );
+    renderSetupPage("/setup?section=members");
+
+    await screen.findByLabelText("Member ID");
+    await user.click(screen.getByRole("tab", { name: t("setup.members.tabs.github") }));
+    await selectMemberType(user, "Machine Account (Machine User)");
+    await user.type(await screen.findByLabelText(t("setup.members.githubUsername")), "octocat");
+    await user.click(screen.getByRole("button", { name: t("setup.members.resolve") }));
+
+    expect(
+      await screen.findByText(t("setup.validation.memberGithubIdentityNotFound")),
+    ).toBeInTheDocument();
+  });
+
+  it("changes the required credential fields when switching person type", async () => {
+    const user = userEvent.setup();
+    vi.mocked(getTeam).mockResolvedValue({
+      project: { name: "Demo", language_code: "en", language_name: "English" },
+      members: [],
+    });
+    renderSetupPage("/setup?section=members");
+
+    await screen.findByLabelText("Member ID");
+    await user.click(screen.getByRole("tab", { name: t("setup.members.tabs.github") }));
+
+    // human: no GitHub auth required.
+    await selectMemberType(user, "Human");
+    expect(await screen.findByText(t("setup.members.githubAuthNotRequired"))).toBeInTheDocument();
+    expect(screen.queryByLabelText(t("setup.members.accessToken"))).not.toBeInTheDocument();
+
+    // machine_user: an access token field appears.
+    await selectMemberType(user, "Machine Account (Machine User)");
+    expect(await screen.findByLabelText(t("setup.members.accessToken"))).toBeInTheDocument();
+    expect(screen.queryByLabelText(t("setup.members.installationId"))).not.toBeInTheDocument();
+
+    // github_apps: installation id / app id / private key path appear instead.
+    await selectMemberType(user, "GitHub Apps");
+    expect(await screen.findByLabelText(t("setup.members.installationId"))).toBeInTheDocument();
+    expect(screen.getByLabelText(t("setup.members.appId"))).toBeInTheDocument();
+    expect(screen.getByLabelText(t("setup.members.privateKeyPath"))).toBeInTheDocument();
+    expect(screen.queryByLabelText(t("setup.members.accessToken"))).not.toBeInTheDocument();
+  });
+
+  it("blocks saving a machine_user member until a valid access token is provided", async () => {
+    const user = userEvent.setup();
+    vi.mocked(getTeam).mockResolvedValue({
+      project: { name: "Demo", language_code: "en", language_name: "English" },
+      members: [],
+    });
+    renderSetupPage("/setup?section=members");
+
+    await fillRequiredMemberBasics(user, { personId: "bot", personName: "Bot" });
+    await user.click(screen.getByRole("tab", { name: t("setup.members.tabs.github") }));
+    await selectMemberType(user, "Machine Account (Machine User)");
+    await user.type(await screen.findByLabelText(t("setup.members.githubUsername")), "bot");
+    await user.type(screen.getByLabelText(t("setup.members.gitEmail")), "bot@example.com");
+
+    const tokenField = screen.getByLabelText(t("setup.members.accessToken"));
+    await user.type(tokenField, "bad-token");
+    expect(
+      await screen.findByText(t("setup.validation.githubAccessTokenInvalid")),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: t("setup.members.addButton") })).toBeDisabled();
+
+    await user.clear(tokenField);
+    await user.type(tokenField, "ghp_0123456789abcdef0123456789abcdef0123");
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: t("setup.members.addButton") })).toBeEnabled(),
+    );
+  });
+
+  it("validates Slack channels and tokens", async () => {
+    const user = userEvent.setup();
+    vi.mocked(getTeam).mockResolvedValue({
+      project: { name: "Demo", language_code: "en", language_name: "English" },
+      members: [],
+    });
+    renderSetupPage("/setup?section=members");
+
+    await screen.findByLabelText("Member ID");
+    await user.click(screen.getByRole("tab", { name: t("setup.members.tabs.slack") }));
+
+    await user.type(
+      await screen.findByLabelText(t("setup.members.slackChannels")),
+      "general, BAD CHANNEL",
+    );
+    expect(await screen.findByText(t("setup.validation.slackChannelsInvalid"))).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText(t("setup.members.slackBotToken")), "not-a-token");
+    expect(await screen.findByText(t("setup.validation.slackBotTokenInvalid"))).toBeInTheDocument();
+  });
+
+  it("applies and clears the character preset on the Basic tab", async () => {
+    const user = userEvent.setup();
+    vi.mocked(getTeam).mockResolvedValue({
+      project: { name: "Demo", language_code: "en", language_name: "English" },
+      members: [],
+    });
+    renderSetupPage("/setup?section=members");
+
+    // The archetype field's label embeds a "Set default value" action button, so
+    // target the input by its preset placeholder instead of the label text.
+    const archetype = (await screen.findByPlaceholderText(
+      "strategic_project_manager",
+    )) as HTMLInputElement;
+    // The default add form applies the "professional" preset, so the archetype
+    // is pre-filled.
+    await waitFor(() => expect(archetype.value).toBe("strategic_project_manager"));
+
+    await user.click(screen.getByRole("button", { name: t("setup.members.clearDefaults") }));
+    await waitFor(() => expect(archetype).toHaveValue(""));
+  });
+
+  it("surfaces a roles loading error", async () => {
+    vi.mocked(getRoleOptions).mockRejectedValue(new Error("roles down"));
+    vi.mocked(getTeam).mockResolvedValue({
+      project: { name: "Demo", language_code: "en", language_name: "English" },
+      members: [],
+    });
+    renderSetupPage("/setup?section=members");
+
+    expect(await screen.findByText(t("setup.members.rolesLoadError"))).toBeInTheDocument();
+  });
+
+  it("runs member diagnostics from the diagnostics tab", async () => {
+    const user = userEvent.setup();
+    vi.mocked(getMemberConfig).mockResolvedValue(memberConfigDetail());
+    vi.mocked(runScenarioDiagnostics).mockResolvedValue({
+      ok: false,
+      active_members: ["alice"],
+      checks: [
+        {
+          section: "github",
+          code: "github_token_missing",
+          status: "error",
+          target: "alice",
+          message: "Token missing",
+          person_id: "alice",
+          context: {},
+        },
+      ],
+      warnings: [],
+      errors: [],
+    });
+    renderSetupPage("/setup?section=members");
+
+    await user.click(await screen.findByRole("button", { name: t("setup.members.editButton") }));
+    await waitFor(() => expect(vi.mocked(getMemberConfig).mock.calls[0]?.[0]).toBe("alice"));
+    await user.click(screen.getByRole("tab", { name: t("setup.members.tabs.diagnostics") }));
+    await user.click(
+      await screen.findByRole("button", { name: t("setup.members.diagnostics.run") }),
+    );
+
+    await waitFor(() => expect(vi.mocked(runScenarioDiagnostics).mock.calls[0]?.[0]).toBe("alice"));
+    // The failing check has no localized title/description, so its raw message
+    // appears in both the alert title and body.
+    expect((await screen.findAllByText("Token missing")).length).toBeGreaterThan(0);
+    expect(screen.queryByText(t("setup.members.diagnostics.ok"))).not.toBeInTheDocument();
+  });
+});
+
+// Mantine Select renders a combobox whose accessible name matches the member
+// GitHub-mode label; open it and pick the option by its visible text.
+async function selectMemberType(user: ReturnType<typeof userEvent.setup>, optionLabel: string) {
+  await user.click(await screen.findByRole("textbox", { name: t("setup.members.githubMode") }));
+  await user.click(await screen.findByRole("option", { name: optionLabel }));
+}
+
+const PATROL_COMMAND_OPTIONS: CommandOption[] = [
+  commandOption({
+    command: "workflows/ticket_driven_workflow",
+    label: "Ticket workflow",
+  }),
+  commandOption({
+    command: "report",
+    label: "Report",
+    arguments: [
+      { name: "target", kind: "positional", required: true, default: "" },
+      { name: "--format", kind: "keyword", required: false, default: "" },
+    ],
+  }),
+];
+
+async function openPatrolTab(user: ReturnType<typeof userEvent.setup>) {
+  renderSetupPage("/setup?section=members&tab=patrol");
+  await user.click(await screen.findByRole("button", { name: t("setup.members.editButton") }));
+  await screen.findByText(t("setup.members.patrol.title"));
+}
+
+describe("PatrolSettingsEditor", () => {
+  beforeEach(() => {
+    // The loaded member has no GitHub linking, so the rest of the form stays
+    // valid and save reflects only the patrol/schedule changes under test.
+    vi.mocked(getMemberConfig).mockResolvedValue(memberConfigDetail());
+    vi.mocked(getCommandOptions).mockResolvedValue({ options: PATROL_COMMAND_OPTIONS });
+  });
+
+  it("explains the shared default when the routine override is off", async () => {
+    const user = userEvent.setup();
+    await openPatrolTab(user);
+
+    expect(
+      await screen.findByText(t("setup.members.patrol.usesServiceDefault")),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByLabelText(t("setup.members.patrol.routineCommands")),
+    ).not.toBeInTheDocument();
+  });
+
+  it("requires a routine when the override is enabled with none selected", async () => {
+    const user = userEvent.setup();
+    await openPatrolTab(user);
+
+    // Clicking the Switch's visible label toggles the member-specific override.
+    await user.click(await screen.findByText(t("setup.members.patrol.overrideRoutine")));
+    expect(await screen.findByText(t("setup.members.patrol.routineRequired"))).toBeInTheDocument();
+    // The error blocks saving even though the rest of the member is valid.
+    expect(screen.getByRole("button", { name: t("setup.members.saveButton") })).toBeDisabled();
+  });
+
+  it("adds and removes a scheduled command", async () => {
+    const user = userEvent.setup();
+    await openPatrolTab(user);
+
+    expect(await screen.findByText(t("setup.members.patrol.noSchedules"))).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: t("setup.members.patrol.addSchedule") }));
+
+    // A freshly added schedule defaults to the first catalog command.
+    expect(
+      await screen.findByDisplayValue("Ticket workflow (workflows/ticket_driven_workflow)"),
+    ).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: t("setup.members.patrol.removeSchedule") }),
+    );
+    expect(await screen.findByText(t("setup.members.patrol.noSchedules"))).toBeInTheDocument();
+  });
+
+  it("converts catalog command args into the task_schedules payload", async () => {
+    const user = userEvent.setup();
+    await openPatrolTab(user);
+
+    await user.click(screen.getByRole("button", { name: t("setup.members.patrol.addSchedule") }));
+    // Switch the schedule's command to the catalog "report" command, which
+    // exposes positional and keyword argument inputs.
+    await user.click(await screen.findByRole("textbox", { name: t("commands.command") }));
+    await user.click(await screen.findByRole("option", { name: /Report \(report\)/ }));
+
+    await user.type(await screen.findByLabelText("target *"), "weekly report");
+    await user.type(screen.getByLabelText("--format"), "pdf");
+
+    await user.click(screen.getByRole("button", { name: t("setup.members.saveButton") }));
+
+    await waitFor(() => expect(updateMemberConfig).toHaveBeenCalledTimes(1));
+    const [, body] = vi.mocked(updateMemberConfig).mock.calls[0];
+    expect(body.task_schedules).toEqual([
+      { command: 'report "weekly report" --format=pdf', schedules: ["0 9 * * *"] },
+    ]);
+  });
+
+  it("edits custom command raw args and converts them into task_schedules", async () => {
+    const user = userEvent.setup();
+    await openPatrolTab(user);
+
+    await user.click(screen.getByRole("button", { name: t("setup.members.patrol.addSchedule") }));
+    await user.click(await screen.findByRole("radio", { name: t("commands.modeCustom") }));
+
+    await user.type(await screen.findByLabelText(t("commands.command")), "my/custom_command");
+    await user.type(screen.getByLabelText(t("commands.rawArgs")), "--verbose");
+    await user.click(screen.getByRole("button", { name: t("setup.members.saveButton") }));
+
+    await waitFor(() => expect(updateMemberConfig).toHaveBeenCalledTimes(1));
+    const [, body] = vi.mocked(updateMemberConfig).mock.calls[0];
+    expect(body.task_schedules).toEqual([
+      { command: "my/custom_command --verbose", schedules: ["0 9 * * *"] },
+    ]);
+  });
+
+  it("switches schedule presets and converts each to a cron expression", async () => {
+    const user = userEvent.setup();
+    await openPatrolTab(user);
+
+    await user.click(screen.getByRole("button", { name: t("setup.members.patrol.addSchedule") }));
+
+    // Default is daily at 09:00.
+    expect(await screen.findByDisplayValue("0 9 * * *")).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("radio", { name: t("setup.members.patrol.cronPresets.hourly") }),
+    );
+    await waitFor(() => expect(screen.getByDisplayValue("0 * * * *")).toBeInTheDocument());
+
+    await user.click(
+      screen.getByRole("radio", { name: t("setup.members.patrol.cronPresets.weekly") }),
+    );
+    await waitFor(() => expect(screen.getByDisplayValue("0 9 * * 1")).toBeInTheDocument());
+
+    await user.click(
+      screen.getByRole("radio", { name: t("setup.members.patrol.cronPresets.custom") }),
+    );
+    // The custom-cron input is seeded from the draft's stored cron string (the
+    // original daily expression), independent of the preset-driven generated cron.
+    const cronField = await screen.findByLabelText(t("setup.members.patrol.cron"));
+    expect(cronField).toHaveValue("0 9 * * *");
+  });
+
+  it("blocks saving when a custom cron is invalid", async () => {
+    const user = userEvent.setup();
+    await openPatrolTab(user);
+
+    await user.click(screen.getByRole("button", { name: t("setup.members.patrol.addSchedule") }));
+    await user.click(
+      await screen.findByRole("radio", { name: t("setup.members.patrol.cronPresets.custom") }),
+    );
+
+    const cronField = await screen.findByLabelText(t("setup.members.patrol.cron"));
+    await user.clear(cronField);
+    await user.type(cronField, "0 9 * *");
+
+    expect(await screen.findByText(t("setup.members.patrol.cronInvalid"))).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: t("setup.members.saveButton") })).toBeDisabled();
+  });
+});
+
+function teamIntelligenceConfig(overrides: Partial<IntelligenceConfig> = {}): IntelligenceConfig {
+  return {
+    config_dir: "/workspace/.guildbotics/config",
+    person_id: null,
+    inherited: false,
+    model_mapping: { default: "models/openai.yml", openai: "models/openai.yml" },
+    models: [
+      {
+        path: "models/openai.yml",
+        provider: "openai",
+        model_class: "OpenAIModel",
+        model_id: "gpt-5",
+      },
+    ],
+    cli_agent_mapping: { default: "codex-cli.yml", codex: "codex-cli.yml" },
+    cli_agents: [
+      {
+        path: "codex-cli.yml",
+        name: "codex",
+        env: {},
+        script: "codex",
+        detected: true,
+        detected_path: "/usr/local/bin/codex",
+      },
+    ],
+    brain_mapping: [
+      { name: "writer", brain_class: "WriterBrain", engine: "llm", target: "default" },
+    ],
+    ...overrides,
+  };
+}
+
+function memberIntelligenceConfig(overrides: Partial<IntelligenceConfig> = {}): IntelligenceConfig {
+  return teamIntelligenceConfig({
+    person_id: "alice",
+    inherited: false,
+    model_mapping: {
+      default: "models/openai.yml",
+      openai: "models/openai.yml",
+      gemini: "models/gemini.yml",
+    },
+    models: [
+      {
+        path: "models/openai.yml",
+        provider: "openai",
+        model_class: "OpenAIModel",
+        model_id: "gpt-5",
+      },
+      {
+        path: "models/gemini.yml",
+        provider: "gemini",
+        model_class: "GeminiModel",
+        model_id: "gemini-2.5",
+      },
+    ],
+    cli_agent_mapping: {
+      default: "codex-cli.yml",
+      codex: "codex-cli.yml",
+      claude: "claude-cli.yml",
+    },
+    cli_agents: [
+      {
+        path: "codex-cli.yml",
+        name: "codex",
+        env: {},
+        script: "codex",
+        detected: true,
+        detected_path: "/usr/local/bin/codex",
+      },
+      {
+        path: "claude-cli.yml",
+        name: "claude",
+        env: {},
+        script: "claude",
+        detected: true,
+        detected_path: "/usr/local/bin/claude",
+      },
+    ],
+    brain_mapping: [],
+    ...overrides,
+  });
+}
+
+async function openTeamIntelligenceAdvanced(user: ReturnType<typeof userEvent.setup>) {
+  renderSetupPage("/setup");
+  // The intelligence section is reached through the sidebar nav (only the
+  // members section is deep-linkable via the URL).
+  await user.click(await screen.findByRole("button", { name: t("setup.nav.intelligence") }));
+  await user.click(await screen.findByRole("button", { name: t("setup.intelligence.advanced") }));
+  // The advanced editor loads its config lazily; wait for a unique label.
+  await screen.findByText(t("setup.intelligence.modelMapping"));
+}
+
+async function openMemberIntelligenceTab(user: ReturnType<typeof userEvent.setup>) {
+  renderSetupPage("/setup?section=members");
+  await user.click(await screen.findByRole("button", { name: t("setup.members.editButton") }));
+  await user.click(await screen.findByRole("tab", { name: t("setup.members.tabs.intelligence") }));
+}
+
+describe("IntelligenceEditor (team default)", () => {
+  beforeEach(() => {
+    vi.mocked(getIntelligenceConfig).mockResolvedValue(teamIntelligenceConfig());
+    vi.mocked(getCliAgentDetections).mockResolvedValue({
+      agents: [
+        { name: "codex", executable: "codex", detected: true, path: "/usr/local/bin/codex" },
+      ],
+    });
+  });
+
+  it("autosaves a model definition edit through updateIntelligenceConfig after debounce", async () => {
+    const user = userEvent.setup();
+    await openTeamIntelligenceAdvanced(user);
+
+    const modelClass = await screen.findByLabelText(t("setup.intelligence.modelClass"));
+    await user.clear(modelClass);
+    await user.type(modelClass, "CustomModel");
+
+    await waitFor(() => expect(updateIntelligenceConfig).toHaveBeenCalledTimes(1), {
+      timeout: 3000,
+    });
+    const body = vi.mocked(updateIntelligenceConfig).mock.calls[0][0];
+    expect(body).toMatchObject({ person_id: null, inherit_team_defaults: false });
+    expect(body.models?.[0]).toMatchObject({
+      path: "models/openai.yml",
+      model_class: "CustomModel",
+    });
+  });
+
+  it("does not autosave repeatedly before the debounce elapses", async () => {
+    const user = userEvent.setup();
+    await openTeamIntelligenceAdvanced(user);
+
+    const modelId = await screen.findByLabelText(t("setup.intelligence.modelId"));
+    await user.type(modelId, "X");
+    // The debounce is 800ms; right after typing nothing has been persisted yet.
+    expect(updateIntelligenceConfig).not.toHaveBeenCalled();
+
+    await waitFor(() => expect(updateIntelligenceConfig).toHaveBeenCalledTimes(1), {
+      timeout: 3000,
+    });
+  });
+
+  it("edits the brain feature-to-engine mapping and sends the new assignment", async () => {
+    const user = userEvent.setup();
+    await openTeamIntelligenceAdvanced(user);
+
+    const engineSelect = await screen.findByRole("textbox", {
+      name: t("setup.intelligence.engine"),
+    });
+    await user.click(engineSelect);
+    await user.click(await screen.findByRole("option", { name: "CLI" }));
+
+    await waitFor(() => expect(updateIntelligenceConfig).toHaveBeenCalledTimes(1), {
+      timeout: 3000,
+    });
+    const body = vi.mocked(updateIntelligenceConfig).mock.calls[0][0];
+    expect(body.brain_mapping?.[0]).toMatchObject({
+      name: "writer",
+      engine: "cli",
+      target: "default",
+    });
+  });
+
+  it("shows a JSON validation error and blocks autosave for malformed env", async () => {
+    const user = userEvent.setup();
+    await openTeamIntelligenceAdvanced(user);
+
+    const envInput = await screen.findByLabelText(t("setup.intelligence.envJson"));
+    await user.click(envInput);
+    await user.paste("{not json");
+
+    expect(await screen.findByText(t("setup.intelligence.envJsonError"))).toBeInTheDocument();
+    await new Promise((resolve) => setTimeout(resolve, 1100));
+    expect(updateIntelligenceConfig).not.toHaveBeenCalled();
+  });
+
+  it("renders the CLI agent detection badge from detections", async () => {
+    const user = userEvent.setup();
+    await openTeamIntelligenceAdvanced(user);
+
+    await screen.findByText(t("setup.intelligence.cliDefinitions"));
+    expect(screen.getAllByText(t("setup.intelligence.detected")).length).toBeGreaterThan(0);
+  });
+
+  it("surfaces a save error returned by updateIntelligenceConfig", async () => {
+    const user = userEvent.setup();
+    vi.mocked(updateIntelligenceConfig).mockRejectedValueOnce(new Error("write blew up"));
+    await openTeamIntelligenceAdvanced(user);
+
+    const modelClass = await screen.findByLabelText(t("setup.intelligence.modelClass"));
+    await user.clear(modelClass);
+    await user.type(modelClass, "BrokenModel");
+
+    expect(await screen.findByText(t("setup.intelligence.saveAdvancedError"))).toBeInTheDocument();
+    expect(screen.getByText("write blew up")).toBeInTheDocument();
+  });
+});
+
+describe("IntelligenceEditor (member override)", () => {
+  beforeEach(() => {
+    // Two providers and two CLI agents are available so the override buttons are
+    // enabled and selecting a non-default option is possible.
+    vi.mocked(getProjectConfig).mockResolvedValue(
+      projectConfig({
+        description: "Demo project",
+        has_openai_api_key: true,
+        has_google_api_key: true,
+      }),
+    );
+    vi.mocked(getCliAgentDetections).mockResolvedValue({
+      agents: [
+        { name: "codex", executable: "codex", detected: true, path: "/usr/local/bin/codex" },
+        { name: "claude", executable: "claude", detected: true, path: "/usr/local/bin/claude" },
+      ],
+    });
+    vi.mocked(getMemberConfig).mockResolvedValue(memberConfigDetail());
+    vi.mocked(getIntelligenceConfig).mockResolvedValue(memberIntelligenceConfig());
+  });
+
+  it("registers an external save callback and persists the override on member save", async () => {
+    const user = userEvent.setup();
+    await openMemberIntelligenceTab(user);
+
+    // Switch the member's default LLM provider to Gemini.
+    await user.click(await screen.findByText(t("setup.intelligence.memberDefaultProvider")));
+    const geminiButton = screen.getByText("Google Gemini").closest("button");
+    if (!geminiButton) {
+      throw new Error("Gemini override button not found");
+    }
+    await user.click(geminiButton);
+
+    await user.click(screen.getByRole("button", { name: t("setup.members.saveButton") }));
+
+    await waitFor(() => expect(updateIntelligenceConfig).toHaveBeenCalledTimes(1));
+    const body = vi.mocked(updateIntelligenceConfig).mock.calls[0][0];
+    expect(body).toMatchObject({ person_id: "alice", inherit_team_defaults: false });
+    expect(body.model_mapping?.default).toBe("models/gemini.yml");
+    // Member overrides do not resend full model/cli/brain definitions.
+    expect("models" in body).toBe(false);
+    expect("brain_mapping" in body).toBe(false);
+  });
+
+  it("edits the member default CLI agent override", async () => {
+    const user = userEvent.setup();
+    await openMemberIntelligenceTab(user);
+
+    await screen.findByText(t("setup.intelligence.memberDefaultCliAgent"));
+    const claudeButton = screen.getByText("Claude Code").closest("button");
+    if (!claudeButton) {
+      throw new Error("Claude override button not found");
+    }
+    await user.click(claudeButton);
+
+    await user.click(screen.getByRole("button", { name: t("setup.members.saveButton") }));
+
+    await waitFor(() => expect(updateIntelligenceConfig).toHaveBeenCalledTimes(1));
+    const body = vi.mocked(updateIntelligenceConfig).mock.calls[0][0];
+    expect(body.cli_agent_mapping?.default).toBe("claude-cli.yml");
+  });
+
+  it("sends inherit_team_defaults when the inherit switch is enabled", async () => {
+    const user = userEvent.setup();
+    await openMemberIntelligenceTab(user);
+
+    await user.click(
+      await screen.findByRole("switch", {
+        name: t("setup.intelligence.inheritTeamDefaults"),
+      }),
+    );
+    expect(await screen.findByText(t("setup.intelligence.inheritingTitle"))).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: t("setup.members.saveButton") }));
+
+    await waitFor(() => expect(updateIntelligenceConfig).toHaveBeenCalledTimes(1));
+    expect(vi.mocked(updateIntelligenceConfig).mock.calls[0][0]).toEqual({
+      config_dir: "/workspace/.guildbotics/config",
+      person_id: "alice",
+      inherit_team_defaults: true,
+    });
+  });
+});

--- a/desktop/src/setup/SetupPage.tsx
+++ b/desktop/src/setup/SetupPage.tsx
@@ -89,7 +89,7 @@ import {
 import { restartBackend } from "../api/backend";
 import { normalizeLanguage } from "../i18n";
 
-function createProjectSchema(t: TFunction | ((key: string) => string)) {
+export function createProjectSchema(t: TFunction | ((key: string) => string)) {
   return z
     .object({
       workspaceDir: z.string().min(1, t("setup.validation.workspaceRequired")),
@@ -171,7 +171,7 @@ type MemberType = (typeof MEMBER_TYPE_OPTIONS)[number];
 type GitHubMemberType = Exclude<MemberType, "">;
 type MemberEditorTab = "basic" | "intelligence" | "patrol" | "github" | "slack" | "diagnostics";
 type CronPreset = "hourly" | "daily" | "weekly" | "custom";
-type ScheduledCommandDraft = {
+export type ScheduledCommandDraft = {
   id: string;
   commandMode: "catalog" | "custom";
   command: string;
@@ -232,8 +232,11 @@ export function SetupPage() {
   });
 
   const appLanguage = normalizeLanguage(i18n.resolvedLanguage ?? i18n.language) ?? "en";
-  const projectLanguage = normalizeLanguage(team.data?.project.language_code);
-  const activeMemberCount = (team.data?.members ?? []).filter((member) => member.is_active).length;
+  const persistedTeam = hasExistingProject ? team.data : undefined;
+  const projectLanguage = normalizeLanguage(persistedTeam?.project.language_code);
+  const activeMemberCount = (persistedTeam?.members ?? []).filter(
+    (member) => member.is_active,
+  ).length;
   const detectedCliAgentNames = useMemo(
     () =>
       new Set(
@@ -272,6 +275,8 @@ export function SetupPage() {
   const [saveState, setSaveState] = useState<"idle" | "saving" | "saved" | "error">("idle");
   const [setupCreated, setSetupCreated] = useState(false);
   const [draftActiveMemberCount, setDraftActiveMemberCount] = useState(0);
+  const [workspaceSwitching, setWorkspaceSwitching] = useState(false);
+  const workspaceSwitchId = useRef(0);
   const canAutosave = hasExistingProject && projectConfig.isSuccess;
   const llmProviderAvailability = useMemo(
     () => ({
@@ -292,7 +297,7 @@ export function SetupPage() {
   );
   const effectiveActiveMemberCount = hasExistingProject
     ? activeMemberCount
-    : Math.max(activeMemberCount, draftActiveMemberCount);
+    : draftActiveMemberCount;
   const coreSections: readonly CoreSection[] = hasExistingProject
     ? CORE_SETUP_SECTIONS_CONFIGURED
     : CORE_SETUP_SECTIONS_INITIAL;
@@ -335,7 +340,7 @@ export function SetupPage() {
     validationSchema,
     saveMutation.mutateAsync,
     setSaveState,
-    canAutosave,
+    canAutosave && !workspaceSwitching,
   );
 
   const setupStatus = useSetupStatus(config.data, effectiveActiveMemberCount, form.values);
@@ -369,9 +374,43 @@ export function SetupPage() {
   };
   const changeWorkspace = (value: string) => {
     form.setFieldValue("workspaceDir", value);
-    if (value.trim()) {
-      localStorage.setItem("guildbotics.workspace", value);
+    const workspace = value.trim();
+    if (!workspace) {
+      return;
     }
+    const switchId = workspaceSwitchId.current + 1;
+    workspaceSwitchId.current = switchId;
+    setWorkspaceSwitching(true);
+    setSaveState("saving");
+    void restartBackend(workspace)
+      .then(async () => {
+        if (workspaceSwitchId.current !== switchId) {
+          return;
+        }
+        setDraftActiveMemberCount(0);
+        queryClient.setQueryData(["team"], undefined);
+        queryClient.setQueryData(["project-config"], undefined);
+        queryClient.invalidateQueries({ queryKey: ["project-config"] });
+        queryClient.invalidateQueries({ queryKey: ["intelligence-config"] });
+        queryClient.invalidateQueries({ queryKey: ["command-options"] });
+        queryClient.invalidateQueries({ queryKey: ["scheduler"] });
+        await Promise.all([
+          queryClient.refetchQueries({ queryKey: ["config"] }),
+          queryClient.refetchQueries({ queryKey: ["team"] }),
+        ]);
+        await queryClient.refetchQueries({ queryKey: ["project-config"] });
+        setSaveState("saved");
+      })
+      .catch(() => {
+        if (workspaceSwitchId.current === switchId) {
+          setSaveState("error");
+        }
+      })
+      .finally(() => {
+        if (workspaceSwitchId.current === switchId) {
+          setWorkspaceSwitching(false);
+        }
+      });
   };
 
   return (
@@ -431,7 +470,7 @@ export function SetupPage() {
           {activeSection === "members" ? (
             <MembersSection
               activeMemberCount={effectiveActiveMemberCount}
-              members={team.data?.members ?? []}
+              members={persistedTeam?.members ?? []}
               config={config.data}
               workspaceDir={form.values.workspaceDir}
               configLocation={form.values.configLocation}
@@ -3440,7 +3479,7 @@ type MemberFieldErrors = Partial<
   >
 >;
 
-function getMemberFieldErrors(
+export function getMemberFieldErrors(
   values: {
     personType: MemberType;
     identity: string;
@@ -3605,7 +3644,7 @@ function getMemberFieldErrors(
   return errors;
 }
 
-function getMemberResolveErrorMessage(
+export function getMemberResolveErrorMessage(
   error: unknown,
   t: TFunction | ((key: string) => string),
 ): string {
@@ -3702,7 +3741,7 @@ function toFormConfigLocation(
   return location === "workspace" ? "workspace" : "home";
 }
 
-function initialProjectValues(
+export function initialProjectValues(
   config: ConfigStatus | undefined,
   appLanguage: ProjectFormValues["language"],
   projectLanguage: ProjectFormValues["language"] | null,
@@ -3747,7 +3786,7 @@ function initialProjectValues(
   };
 }
 
-function toProjectSetupRequest(
+export function toProjectSetupRequest(
   values: ProjectFormValues,
   config: ConfigStatus | undefined,
   options: { envFileOption?: ProjectFormValues["envFileOption"] } = {},
@@ -3777,7 +3816,7 @@ function toProjectSetupRequest(
   };
 }
 
-function toProjectUpdateRequest(
+export function toProjectUpdateRequest(
   values: ProjectFormValues,
   config: ConfigStatus | undefined,
   snapshot: ProjectConfig,
@@ -3955,7 +3994,7 @@ function getCharacterPresetExamples(
   };
 }
 
-function parseCharacterFields(character: Record<string, unknown>): {
+export function parseCharacterFields(character: Record<string, unknown>): {
   archetype: string;
   traits: string[];
   interests: string[];
@@ -3992,7 +4031,7 @@ function parseCharacterFields(character: Record<string, unknown>): {
   };
 }
 
-function buildCharacterPayload({
+export function buildCharacterPayload({
   archetype,
   traits,
   interests,
@@ -4064,7 +4103,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function toIntelligenceUpdatePayload(config: IntelligenceConfig, savePersonId?: string) {
+export function toIntelligenceUpdatePayload(config: IntelligenceConfig, savePersonId?: string) {
   const personId = savePersonId || config.person_id;
   if (config.person_id && config.inherited) {
     return {
@@ -4116,7 +4155,7 @@ function stringOrEmpty(value: unknown): string {
   return typeof value === "string" ? value : "";
 }
 
-function parseGitHub(projectUrl: string, repositoryUrl: string) {
+export function parseGitHub(projectUrl: string, repositoryUrl: string) {
   const normalizedProjectUrl = projectUrl.trim();
   const normalizedRepositoryUrl = repositoryUrl.trim();
   const projectParts = normalizedProjectUrl.split("/");
@@ -4213,7 +4252,7 @@ function scheduledCommandToDraft(
   };
 }
 
-function createScheduledCommandDraft(command = ""): ScheduledCommandDraft {
+export function createScheduledCommandDraft(command = ""): ScheduledCommandDraft {
   return {
     id: newDraftId(),
     commandMode: command ? "catalog" : "custom",
@@ -4229,7 +4268,7 @@ function createScheduledCommandDraft(command = ""): ScheduledCommandDraft {
   };
 }
 
-function buildTaskSchedules(
+export function buildTaskSchedules(
   drafts: ScheduledCommandDraft[],
   commandOptionByValue: Map<string, CommandOption>,
 ): MemberTaskSchedule[] {
@@ -4248,7 +4287,7 @@ function buildTaskSchedules(
   }));
 }
 
-function buildScheduledCommandExpression(
+export function buildScheduledCommandExpression(
   draft: ScheduledCommandDraft,
   commandOptionByValue: Map<string, CommandOption>,
 ): string {
@@ -4280,7 +4319,7 @@ function buildSetupCommandArgs(
   return [...args, ...splitCommandLine(rawArgs)];
 }
 
-function parseCommandExpression(expression: string, commandCatalog: CommandOption[]) {
+export function parseCommandExpression(expression: string, commandCatalog: CommandOption[]) {
   const command = expression.trim();
   const option = [...commandCatalog]
     .sort((a, b) => b.command.length - a.command.length)
@@ -4298,7 +4337,7 @@ function parseCommandExpression(expression: string, commandCatalog: CommandOptio
   return { option: null, command: first, args: rest.join(" ") };
 }
 
-function draftToCron(draft: ScheduledCommandDraft): string {
+export function draftToCron(draft: ScheduledCommandDraft): string {
   const minute = clampInteger(draft.minute, 0, 59);
   const hour = clampInteger(draft.hour, 0, 23);
   if (draft.scheduleMode === "hourly") {
@@ -4313,7 +4352,7 @@ function draftToCron(draft: ScheduledCommandDraft): string {
   return draft.cron.trim();
 }
 
-function parseCron(schedule: string): {
+export function parseCron(schedule: string): {
   mode: CronPreset;
   minute: number;
   hour: number;
@@ -4350,7 +4389,7 @@ function parseCron(schedule: string): {
   return { mode: "custom", minute: toCronNumber(minute, 0), hour: 9, weekday: "1" };
 }
 
-function isValidCron(schedule: string): boolean {
+export function isValidCron(schedule: string): boolean {
   return schedule.trim().split(/\s+/).length === 5;
 }
 
@@ -4362,7 +4401,7 @@ function clampInteger(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, Math.trunc(value)));
 }
 
-function splitCommandLine(value: string): string[] {
+export function splitCommandLine(value: string): string[] {
   const args: string[] = [];
   const pattern = /"([^"]*)"|'([^']*)'|(\S+)/g;
   for (const match of value.matchAll(pattern)) {
@@ -4371,7 +4410,7 @@ function splitCommandLine(value: string): string[] {
   return args.filter(Boolean);
 }
 
-function quoteCommandArg(value: string): string {
+export function quoteCommandArg(value: string): string {
   if (!/\s/.test(value)) {
     return value;
   }

--- a/desktop/src/test/setup.ts
+++ b/desktop/src/test/setup.ts
@@ -30,3 +30,10 @@ Object.defineProperty(window, "ResizeObserver", {
   writable: true,
   value: ResizeObserverMock,
 });
+
+// jsdom does not implement scrollIntoView, which Mantine's Combobox calls on a
+// timer after an option is selected. Provide a no-op so it does not surface as
+// an unhandled error during tests.
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}

--- a/desktop/src/trace.test.ts
+++ b/desktop/src/trace.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, it } from "vitest";
+
+import type { PromptTraceEntry } from "./api/client";
+import { buildTraceGroups } from "./trace";
+
+function traceEntry(overrides: Partial<PromptTraceEntry>): PromptTraceEntry {
+  return {
+    event: "llm.request",
+    timestamp: "2026-06-04T01:00:00Z",
+    person_id: "alice",
+    brain: "brains/default.yml",
+    command: "",
+    target: "",
+    cwd: "/workspace",
+    description: "",
+    transcript: "",
+    prompt: "",
+    response: "",
+    error: "",
+    fields: {},
+    ...overrides,
+  };
+}
+
+describe("buildTraceGroups ordering", () => {
+  it("pairs a response with a later matching request entry", () => {
+    const response = traceEntry({
+      event: "llm.response",
+      timestamp: "2026-06-04T01:00:02Z",
+      response: "done",
+      fields: { model: "gpt" },
+    });
+    const request = traceEntry({
+      event: "llm.request",
+      timestamp: "2026-06-04T01:00:01Z",
+      prompt: "hello",
+      fields: { model: "gpt" },
+    });
+
+    const groups = buildTraceGroups([response, request]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]).toMatchObject({
+      kind: "llm",
+      request,
+      response,
+      single: null,
+      personId: "alice",
+      brain: "brains/default.yml",
+    });
+  });
+
+  it("does not pair a request that appears before its response", () => {
+    const request = traceEntry({
+      event: "llm.request",
+      timestamp: "2026-06-04T01:00:01Z",
+      prompt: "hello",
+      fields: { model: "gpt" },
+    });
+    const response = traceEntry({
+      event: "llm.response",
+      timestamp: "2026-06-04T01:00:02Z",
+      response: "done",
+      fields: { model: "gpt" },
+    });
+
+    const groups = buildTraceGroups([request, response]);
+
+    // The request precedes the response, so the response cannot find a later
+    // matching request: both remain as separate single/response groups.
+    expect(groups).toHaveLength(2);
+    expect(groups[0]).toMatchObject({ request, response: null, single: null });
+    expect(groups[1]).toMatchObject({ request: null, response, single: null });
+  });
+
+  it("pairs multiple mixed request/response entries for the same target", () => {
+    const responseB = traceEntry({
+      event: "llm.response",
+      timestamp: "2026-06-04T01:00:04Z",
+      response: "second",
+      fields: { model: "gpt" },
+    });
+    const responseA = traceEntry({
+      event: "llm.response",
+      timestamp: "2026-06-04T01:00:02Z",
+      response: "first",
+      fields: { model: "gpt" },
+    });
+    const requestB = traceEntry({
+      event: "llm.request",
+      timestamp: "2026-06-04T01:00:03Z",
+      prompt: "second?",
+      fields: { model: "gpt" },
+    });
+    const requestA = traceEntry({
+      event: "llm.request",
+      timestamp: "2026-06-04T01:00:01Z",
+      prompt: "first?",
+      fields: { model: "gpt" },
+    });
+
+    // Newest-first ordering as the UI receives it.
+    const groups = buildTraceGroups([responseB, requestB, responseA, requestA]);
+
+    expect(groups).toHaveLength(2);
+    expect(groups[0]).toMatchObject({ request: requestB, response: responseB, single: null });
+    expect(groups[1]).toMatchObject({ request: requestA, response: responseA, single: null });
+  });
+
+  it("keeps responses unpaired when the model field differs", () => {
+    const response = traceEntry({
+      event: "llm.response",
+      timestamp: "2026-06-04T01:00:02Z",
+      response: "done",
+      fields: { model: "gpt-4" },
+    });
+    const request = traceEntry({
+      event: "llm.request",
+      timestamp: "2026-06-04T01:00:01Z",
+      prompt: "hello",
+      fields: { model: "gpt-3" },
+    });
+
+    const groups = buildTraceGroups([response, request]);
+
+    expect(groups).toHaveLength(2);
+    expect(groups[0]).toMatchObject({ request: null, response, single: null });
+    expect(groups[1]).toMatchObject({ request, response: null, single: null });
+  });
+
+  it("pairs entries that both omit model and cli_agent fields", () => {
+    const response = traceEntry({
+      event: "llm.response",
+      timestamp: "2026-06-04T01:00:02Z",
+      response: "done",
+    });
+    const request = traceEntry({
+      event: "llm.request",
+      timestamp: "2026-06-04T01:00:01Z",
+      prompt: "hello",
+    });
+
+    const groups = buildTraceGroups([response, request]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]).toMatchObject({ request, response, single: null });
+  });
+
+  it("pairs cli_agent entries by their cli_agent field", () => {
+    const response = traceEntry({
+      event: "cli_agent.response",
+      timestamp: "2026-06-04T01:00:02Z",
+      response: "done",
+      fields: { cli_agent: "codex" },
+    });
+    const request = traceEntry({
+      event: "cli_agent.request",
+      timestamp: "2026-06-04T01:00:01Z",
+      prompt: "hello",
+      fields: { cli_agent: "codex" },
+    });
+
+    const groups = buildTraceGroups([response, request]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]).toMatchObject({ kind: "cli", request, response, single: null });
+  });
+});
+
+describe("buildTraceGroups kind classification", () => {
+  it("classifies llm events as llm", () => {
+    const groups = buildTraceGroups([traceEntry({ event: "llm.request" })]);
+    expect(groups[0]?.kind).toBe("llm");
+  });
+
+  it("classifies cli_agent events as cli", () => {
+    const groups = buildTraceGroups([traceEntry({ event: "cli_agent.request" })]);
+    expect(groups[0]?.kind).toBe("cli");
+  });
+
+  it("classifies chat events as chat", () => {
+    const groups = buildTraceGroups([traceEntry({ event: "chat.reply_input" })]);
+    expect(groups[0]?.kind).toBe("chat");
+  });
+
+  it("classifies unknown events as trace", () => {
+    const groups = buildTraceGroups([traceEntry({ event: "something.else" })]);
+    expect(groups[0]?.kind).toBe("trace");
+  });
+});
+
+describe("buildTraceGroups single and parse-error entries", () => {
+  it("keeps a chat single event as its own group", () => {
+    const entry = traceEntry({ event: "chat.message", timestamp: "2026-06-04T01:00:03Z" });
+
+    const groups = buildTraceGroups([entry]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]).toMatchObject({ request: null, response: null, single: entry });
+  });
+
+  it("keeps a parse-error single event separate from a request/response pair", () => {
+    const parseError = traceEntry({
+      event: "prompt_trace.parse_error",
+      timestamp: "2026-06-04T01:00:05Z",
+      error: "bad json",
+    });
+    const response = traceEntry({
+      event: "llm.response",
+      timestamp: "2026-06-04T01:00:02Z",
+      response: "done",
+      fields: { model: "gpt" },
+    });
+    const request = traceEntry({
+      event: "llm.request",
+      timestamp: "2026-06-04T01:00:01Z",
+      prompt: "hello",
+      fields: { model: "gpt" },
+    });
+
+    const groups = buildTraceGroups([parseError, response, request]);
+
+    expect(groups).toHaveLength(2);
+    expect(groups[0]).toMatchObject({ kind: "trace", single: parseError });
+    expect(groups[1]).toMatchObject({ kind: "llm", request, response, single: null });
+  });
+
+  it("does not pair a response with a request of a different person", () => {
+    const response = traceEntry({
+      event: "llm.response",
+      timestamp: "2026-06-04T01:00:02Z",
+      person_id: "alice",
+      response: "done",
+      fields: { model: "gpt" },
+    });
+    const request = traceEntry({
+      event: "llm.request",
+      timestamp: "2026-06-04T01:00:01Z",
+      person_id: "bob",
+      prompt: "hello",
+      fields: { model: "gpt" },
+    });
+
+    const groups = buildTraceGroups([response, request]);
+
+    expect(groups).toHaveLength(2);
+    expect(groups[0]).toMatchObject({ response, request: null });
+    expect(groups[1]).toMatchObject({ request, response: null });
+  });
+});

--- a/desktop/vite.config.ts
+++ b/desktop/vite.config.ts
@@ -46,6 +46,9 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     setupFiles: "./src/test/setup.ts",
+    // Vitest owns the `src/**` unit/component tests only. The Playwright
+    // real-browser journeys under `e2e/**` must never be collected by Vitest.
+    exclude: ["node_modules", "dist", ".idea", ".git", ".cache", "e2e/**"],
   },
 });
 

--- a/docs/test_gap_analysis.ja.md
+++ b/docs/test_gap_analysis.ja.md
@@ -31,6 +31,134 @@ Desktop 側:
 - P1: 頻繁に変更される、または分岐が多い。早期に追加するべき。
 - P2: 重要だが変更頻度や影響範囲が限定的。P0/P1 の後で追加する。
 
+## セッション実施計画（TODO）
+
+このリストは、上記の不足テストを「1 セッション = 1 コンテキストウィンドウで完了できる単位」に分割したものである。分割方針:
+
+- 対象ソースの近さ（共有コンテキスト）でまとめる。`App.tsx`(約2150行) / `SetupPage.tsx`(約4400行) / `runtime.py`(約1060行) は巨大なため複数セッションに分ける。
+- Python track と Desktop track は独立しており、任意の順で（並行でも）進められる。
+- Phase 0 (P0) → Phase 1 (P1) → Phase 2 (P2) の順を推奨。各 track 内は番号順だと依存（基盤 → 応用）が自然。
+- 各セッションの完了条件は「該当テストの追加 + 関連品質チェックが green」。
+  - Python: `uv run --no-sync ruff check guildbotics` / `mypy guildbotics` / `pylint guildbotics` / 該当 `pytest`
+  - Desktop: `cd desktop && npm run format:check && npm run lint && npm run typecheck && npm run duplicates && npm run test`
+
+進め方: 各セッション開始時にこのファイルを読み、担当セッションのチェックを完了時に `[x]` へ更新する。
+
+### Phase 0 — P0（主要機能の regression 防止）
+
+Python track:
+
+- [x] **S1 — app_api models + events** ✅ `test_models.py`(24) + `test_events.py`(16) = 40 cases, green
+  - 対象: `guildbotics/app_api/models.py`, `events.py`
+  - 追加: `tests/guildbotics/app_api/test_models.py`, `test_events.py`
+  - 範囲: 「Python backend / CLI: Unit Test」の `models.py`, `events.py` 節
+- [x] **S2 — app_api lifecycle** ✅ `test_lifecycle.py` 20 cases, green
+  - 対象: `guildbotics/app_api/lifecycle.py`
+  - 追加: `tests/guildbotics/app_api/test_lifecycle.py`
+  - 範囲: 「Unit Test」の `lifecycle.py` 節（status transition / only 選択 / stop 順序 / timeout / metadata）
+- [x] **S3 — app_api runtime（設定・workspace 系）** ✅ `test_runtime_config.py` 19 cases, green
+  - 対象: `guildbotics/app_api/runtime.py`
+  - 追加: `tests/guildbotics/app_api/test_runtime_config.py`
+  - 範囲: `runtime.py` 節のうち `get_config_status` / `set_workspace` / `get_team_summary` / prompt trace / `detect_cli_agents`
+- [x] **S4 — app_api runtime（command 系）** ✅ `test_runtime_commands.py` 25 cases, green
+  - 対象: `guildbotics/app_api/runtime.py`
+  - 追加: `tests/guildbotics/app_api/test_runtime_commands.py`
+  - 範囲: `runtime.py` 節のうち `get_command_options` / `run_command` / `start_scheduler`
+- [x] **S5 — app_api intelligences** ✅ `test_intelligences.py` 16 cases, green
+  - 対象: `guildbotics/app_api/intelligences.py`
+  - 追加: `tests/guildbotics/app_api/test_intelligences.py`
+  - 範囲: 「Unit Test」の `intelligences.py` 節
+- [x] **S6 — api.py endpoint integration** ✅ `test_api.py` を 118 tests へ拡張（auth matrix / 500 / not-found / validation / conflict / POST /verify 等の不足ブランチを追加）, green
+  - 対象: `guildbotics/app_api/api.py`（`TestClient`）
+  - 追加/更新: `tests/guildbotics/app_api/test_api.py` を拡張
+  - 範囲: 「API Integration Test」の `api.py` 節（auth / config / members / intelligences / scheduler / prompt trace / commands / diagnostics endpoint）
+- [x] **S7 — websocket integration** ✅ 新規 `test_api_ws.py` 9 cases（success / invalid-token 1008 close / history replay / live delivery / disconnect cleanup, events+logs）, green
+  - 対象: `guildbotics/app_api/api.py` の `/events` `/logs`
+  - 追加: `tests/guildbotics/app_api/test_api_ws.py`
+  - 範囲: 「API Integration Test」の websocket 節
+
+Desktop track:
+
+- [x] **S8 — api/client.ts + api/backend.ts** ✅ `client.test.ts`(24) + `backend.test.ts`(10) = 34 cases, green
+  - 対象: `desktop/src/api/client.ts`, `backend.ts`
+  - 追加: `desktop/src/api/client.test.ts`, `backend.test.ts`
+  - 範囲: 「Desktop frontend: Unit Test」の `client.ts`, `backend.ts` 節
+- [x] **S9 — SetupPage.tsx 純粋関数** ✅ 純粋関数を `export` 化し `SetupPage.test.tsx` に 95 cases 追加, green
+  - 対象: `desktop/src/setup/SetupPage.tsx`（pure functions）
+  - 追加/更新: `desktop/src/setup/SetupPage.test.tsx` を拡張
+  - 範囲: 「Unit Test」の `SetupPage.tsx の純粋関数` 節（schema / parseGitHub / request 変換 / member errors / character / intelligence payload / patrol・schedule helpers）
+- [x] **S10 — App.tsx 純粋関数（+ trace.ts / i18n.ts 拡充）** ✅ App 47 + trace 13 + i18n 8 = 68 cases 追加, green
+  - 対象: `desktop/src/App.tsx`（pure functions）, `trace.ts`, `i18n.ts`
+  - 追加/更新: `desktop/src/App.test.tsx`, `trace.test.ts`(新規 or 既存), `i18n.test.ts` を拡張
+  - 範囲: 「Unit Test」の `App.tsx の純粋関数` 節 + `trace.ts`(P1) + `i18n.ts`(P1) 節
+- [x] **S11 — Bootstrap + App routing + Service Runtime（component）** ✅ `Bootstrap.test.tsx`(5) + `ServiceRuntime.test.tsx`(17) = 22 cases, green
+  - 対象: `desktop/src/Bootstrap.tsx`, `App.tsx`(routing / `ServiceRuntimeSection`)
+  - 追加: `desktop/src/Bootstrap.test.tsx` ほか component test
+  - 範囲: 「Component Test」の `Bootstrap` / `App routing` / `Service Runtime 画面` 節
+- [x] **S12 — Commands + Setup（component）** ✅ `Commands.test.tsx`(11) + `SetupPage.test.tsx` の SetupPage component 群, 全 203 desktop tests green
+  - 対象: `App.tsx`(`CommandsPage`), `setup/SetupPage.tsx`(`ProjectSection` ほか Setup 全体)
+  - 追加: component test
+  - 範囲: 「Component Test」の `Commands 画面` / `Setup 画面` 節
+- [x] **S13 — Members editor + Patrol settings（component）** ✅ `SetupPage.test.tsx` に Members 12 + Patrol 8 = 20 cases 追加, desktop 223 tests green
+  - 対象: `setup/SetupPage.tsx`(`MembersSection`, `PatrolSettingsEditor`)
+  - 追加: component test
+  - 範囲: 「Component Test」の `Members editor` / `Patrol settings` 節
+- [x] **S14 — API client + component integration（mock server, P0）** ✅ `integration/ApiIntegration.test.tsx` 7 cases（実 client.ts を fetch/WS 境界モックで検証）, desktop 230 tests green
+  - 対象: Service Runtime / Setup / Commands と mock API の結合
+  - 追加: integration test（mock server）
+  - 範囲: 「Integration / E2E」の `API client + component integration` 節
+
+### Phase 1 — P1（変更頻度・分岐が多い領域）
+
+Python track:
+
+- [x] **S15 — verify / diagnostics + cli_agents** ✅ `test_verify.py`(25) + `test_cli_agents.py`(25) + 新規 `test_diagnostics.py`(22) = 72 tests, green
+  - 対象: `guildbotics/app_api/verify.py`, `diagnostics.py`, `cli_agents.py`
+  - 追加/更新: `tests/guildbotics/app_api/test_verify.py` 拡張 + `test_diagnostics.py`, `test_cli_agents.py`
+  - 範囲: 「Unit Test」の `verify.py / diagnostics.py`, `cli_agents.py` 節
+- [x] **S16 — command runner / command specs 拡充** ✅ `test_command_chain.py` 22 cases, green
+  - 対象: `guildbotics/drivers/command_runner.py`, `guildbotics/commands/*`
+  - 追加/更新: `tests/guildbotics/...` の該当テスト
+  - 範囲: 「Unit Test」の `command runner / command specs` 節（pipe/shared_state 順序、child failure、localized fallback 等）
+- [x] **S17 — setup service / config write 拡充** ✅ `test_setup_service_config_write.py` 16 cases, green
+  - 対象: `guildbotics/editions/simple/setup_service.py`
+  - 追加/更新: 該当テスト
+  - 範囲: 「Unit Test」の `setup service / config write` 節
+- [x] **S18 — real temp project integration + Local API sidecar smoke** ✅ `test_api_integration.py`(4) + `test_sidecar_smoke.py`(4) = 8 cases, green
+  - 対象: `api.py` end-to-end（temp workspace） + `python -m guildbotics.app_api` 起動
+  - 追加: integration / smoke test
+  - 範囲: 「API Integration Test」の `real temporary project integration` 節 + 「E2E / packaging」の `Local API sidecar smoke` 節
+
+Desktop track:
+
+- [x] **S19 — Intelligence editor + Diagnostics（component）** ✅ `SetupPage.test.tsx` に Intelligence 9 + 新規 `Diagnostics.test.tsx` 12 = 21 cases, desktop 251 tests green
+  - 対象: `setup/SetupPage.tsx`(`IntelligenceEditor`), `App.tsx`(`DiagnosticsPage`)
+  - 追加: component test
+  - 範囲: 「Component Test」の `Intelligence editor` / `Diagnostics 画面` 節
+- [x] **S20 — Playwright E2E 基盤 + 初回 setup journey** ✅ `playwright.config.ts` + `e2e/start-stack.mjs`(実backend+vite harness) + `e2e/setup.spec.ts`(journey①, chromium green, `project.yml` 実書き込み検証), vitest 251 維持
+  - 対象: 実ブラウザ E2E 基盤（Playwright）+ journey① 初回 setup happy path
+  - 追加: `desktop/playwright.config.ts`, `desktop/e2e/` 雛形（`webServer` で Local API を temp workspace + token 付き起動 → `/health` 待ち → vite frontend、browser-preview token mode で接続）, 専用 CI ジョブ骨子, journey①（作成後に backend が `project.yml` を実書き込みしたことまで確認）
+  - 範囲: 「Integration / E2E」§`Playwright E2E（lean-but-real journeys）` の harness + journey①
+- [x] **S21 — Service Runtime + Commands journeys** ✅ `e2e/service.spec.ts`(journey③ start→running→stop + scheduler GitHub guard) + `e2e/commands.spec.ts`(journey④ 実 `/commands/run`+`/events` ストリーム→history Success), harness を setup/configured 2スタックに分離, e2e 5 specs green
+  - 対象: 実 backend + 実 websocket 相手の runtime / commands フロー
+  - 追加: journey③ scheduler start(scheduler/events/both)→running→stop, journey④ command 実行→`/events` ストリーム→history 表示
+  - 範囲: 同節 journey③④
+- [x] **S22 — member追加 + diagnostics + 起動失敗 journeys** ✅ `e2e/members.spec.ts`(journey② 追加→`person.yml` 実永続) + `e2e/diagnostics.spec.ts`(journey⑤ 実 scenario 実行→結果描画) + `e2e/failure.spec.ts`(journey⑥ backend down→Bootstrap error→control server で復帰→retry, 決定論的), e2e 全6 journey green×2
+  - 対象: member 反映 / diagnostics 描画 / backend ダウン時の回復
+  - 追加: journey② member 追加→team 反映, journey⑤ verify・scenario 実行→結果描画, journey⑥ backend down→Bootstrap error→retry
+  - 範囲: 同節 journey②⑤⑥
+
+### Phase 2 — P2（影響範囲が限定的・packaging 系）
+
+- [ ] **S23 — Tauri ネイティブ最小ティア（tauri-driver, workflow_dispatch 想定）** ⏸ 保留（実 OS + Tauri runtime が必要）
+  - 対象: Tauri sidecar `backend_info` / workspace restore / file picker（dialog/shell plugin）/ packaged sidecar の first health / app close 時の sidecar 終了
+  - 追加: tauri-driver/WebDriver smoke（通常 push CI ではなく workflow_dispatch / release workflow 側）
+  - 範囲: 「Integration / E2E」§`Tauri ネイティブ smoke（tauri-driver）` + 「E2E / packaging」§`macOS Tauri smoke`
+
+E2E 方針（lean-but-real）: ブラウザ E2E は「振る舞いパターン総当たり」ではなく、実 `client.ts ↔ FastAPI ↔ EventBus(ws)` を貫く **critical journey** に絞る。分岐網羅は S9〜S19 のコンポーネント/統合層に委ね、ピラミッドを維持する。E2E は push CI から隔離し専用ジョブで回す。
+
+合計 23 セッション（Phase 0: 14 / Phase 1: 8 / Phase 2: 1）。1 セッションが大きすぎると感じた場合は、対象節の小見出し単位でさらに分割してよい。
+
 ## Desktop frontend: Unit Test
 
 ### P0: `desktop/src/api/client.ts`
@@ -295,21 +423,34 @@ Desktop 側:
 - Setup: config/project/member/intelligence API を mock し、初回 setup から member 追加までを検証する。
 - Commands: command options / run / websocket event を mock し、history 更新まで検証する。
 
-### P1: Browser-level smoke test
+### P1: Playwright E2E（lean-but-real journeys）
 
-不足しているテスト:
+方針: Vitest + jsdom のコンポーネント/統合テスト（S9〜S19, S14）が分岐網羅を担うのに対し、ここでは **実ブラウザ engine + 実 Local API バックエンド**でしか検証できない領域に絞る。具体的には実 `client.ts ↔ FastAPI ↔ EventBus(websocket)` のワイヤ契約、実 setup がバックエンドで実ファイルを書く一気通貫、実 DOM のレイアウト/フォーカス/タイミング。振る舞いパターンの総当たりはしない（コンポーネント層に委譲しピラミッドを維持）。
 
-- `npm run dev` で `/service`, `/commands`, `/diagnostics`, `/setup` が表示できる。
-- mock API mode または dev token mode で backend 起動失敗画面と retry を確認する。
-- 主要 viewport で sidebar / workspace が重ならない。
+実行基盤（harness）:
 
-### P2: Tauri packaging smoke test
+- `desktop/playwright.config.ts` の `webServer` で `scripts/desktop-dev-all.sh` 相当（Python Local API を temp workspace + `--token` 付きで起動 → `/health` 待ち → vite frontend を起動）を立ち上げる。
+- frontend は `VITE_GUILDBOTICS_API_TOKEN`（browser-preview mode, Tauri 非依存）で実 backend に接続する。
+- 各テストは隔離した temp workspace を使い、終了時に backend/前面プロセスを確実に停止する。
+- 通常 push CI からは隔離し、専用ジョブ（workflow_dispatch / nightly / label gate）で実行する。
 
-不足しているテスト:
+カバーする critical journey（各 journey に必要最小の動作バリエーションのみ）:
+
+1. 初回 setup happy path: 空 temp workspace → project 入力 → 作成 → `/service` へ遷移。**backend が `project.yml` を実書き込み**したことを確認。
+2. member 追加: setup の members から追加 → `/team`（または members 一覧）に反映される。
+3. Service Runtime: scheduler / events / both で start → 実 websocket で running 状態が反映 → stop で stopped。
+4. Commands: sample command 実行 → 実 `/commands/run` + `/events` 経由で output が history にストリーム表示される。
+5. Diagnostics: verify / scenario diagnostics を実行 → 結果（ok/warning/error）が描画される。
+6. critical failure: backend ダウン状態 → Bootstrap の error 表示 → backend 復帰後の retry で起動できる。
+
+### P2: Tauri ネイティブ smoke（tauri-driver）
+
+不足しているテスト（packaged app / ネイティブ bridge 固有。実 OS + Tauri runtime が必要で workflow_dispatch / release workflow 側に隔離）:
 
 - sidecar から `backend_info` を取得し、frontend が health check に到達する。
 - workspace restore が packaged app で機能する。
 - Tauri dialog / shell plugin を使う file picker / open path の smoke test。
+- packaged sidecar の first health response、app close 時に sidecar が終了する。
 
 ## Python backend / CLI: Unit Test
 
@@ -317,12 +458,14 @@ Desktop 側:
 
 不足しているテスト:
 
-- `MemberTaskSchedule` が five-field cron だけを許可する。
+- `PersonTaskScheduleInput`（`guildbotics/editions/simple/setup_service.py`）が five-field cron だけを許可する。
 - blank schedule を除外する。
 - `SchedulerStartRequest.only` が `scheduler` / `events` 以外を拒否する。
 - `SchedulerStartRequest.max_consecutive_errors` / `routine_interval_minutes` が 1 以上である。
 - request/response model が Path を JSON へ安全に serialize する。
-- `MemberConfigUpdateRequest` / `ProjectConfigUpdateRequest` の optional secret fields の空文字扱い。
+- `ProjectConfigUpdateRequest` / `ProjectUpdateInput` の optional secret fields の空文字扱い（`""` と `None` を区別して既存 secret を保持する）。
+
+> 注: 旧版にあった `MemberTaskSchedule` / `MemberConfigUpdateRequest` は実装に存在しない。上記の実モデルで読み替える（S1 で確認済み）。
 
 ### P0: `guildbotics/app_api/events.py`
 
@@ -543,28 +686,18 @@ Desktop 側:
 - `/config/status` が working directory を返す。
 - process shutdown が clean。
 
-### P2: Desktop + backend smoke
+### P1: Desktop + backend journey（→「Playwright E2E」へ統合）
 
-不足しているテスト:
+frontend dev server + 実 Local API を起動して browser でユーザーフローを検証する内容（`/service` runtime status、初回 setup happy path、command 実行→history、verify 結果描画）は、上の「Desktop frontend: Integration / E2E」§「Playwright E2E（lean-but-real journeys）」の journey ①③④⑤ に統合した。本節は重複のためそちらを正とする。
 
-- frontend dev server + Local API を起動し、browser test で `/service` の runtime status を表示する。
-- setup page で temp workspace を入力して initial setup を作成する happy path。
-- commands page で sample command を実行し output が history に出る。
-- diagnostics page で verify result を表示する。
+### P2: macOS Tauri smoke（→「Tauri ネイティブ smoke」へ統合）
 
-### P2: macOS Tauri smoke
-
-不足しているテスト:
-
-- Tauri app が sidecar を起動し `backend_info` を返す。
-- packaged sidecar の first health response。
-- app close 時に sidecar が終了する。
-- file picker / open path の plugin integration。
+Tauri app の sidecar 起動・`backend_info`・packaged sidecar の first health・app close 時の sidecar 終了・file picker / open path plugin integration は、上の §「Tauri ネイティブ smoke（tauri-driver）」に統合した。実 OS + Tauri runtime が必要なため workflow_dispatch / release workflow に隔離する。
 
 ## CI 上の今後の検討
 
 - Python coverage threshold を module ごとに設定する。
 - Desktop coverage を導入する場合は、最初は threshold を低めに置き、P0 領域追加に合わせて段階的に上げる。
-- E2E は通常 push CI では最小 smoke のみにし、macOS/Tauri packaging smoke は workflow_dispatch または release workflow に寄せる。
+- Playwright E2E（lean-but-real journeys）は push CI の lint/test ジョブから隔離し、専用ジョブ（workflow_dispatch / nightly / label gate）で実 backend + frontend を起動して回す。Tauri ネイティブ smoke は workflow_dispatch / release workflow に寄せる。
 - external service が必要なテストは default CI では skip し、契約 test / stub test を default に置く。
 

--- a/guildbotics/app_api/cli_agents.py
+++ b/guildbotics/app_api/cli_agents.py
@@ -30,7 +30,7 @@ GUI_APP_PATHS = (
 
 def get_cli_agent_search_path(path: str | None = None) -> str:
     current = os.environ.get("PATH") if path is None else path
-    if current == "":
+    if path is not None and current == "":
         return ""
     entries = [entry for entry in (current or os.defpath).split(os.pathsep) if entry]
     home = Path.home()

--- a/guildbotics/app_api/cli_agents.py
+++ b/guildbotics/app_api/cli_agents.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+import shutil
 from pathlib import Path
 from typing import Any, Literal, cast
 
@@ -13,6 +15,39 @@ CLI_AGENT_EXECUTABLES: tuple[CliAgentName, ...] = (
     "claude",
     "copilot",
 )
+
+GUI_APP_PATHS = (
+    "/opt/homebrew/bin",
+    "/opt/homebrew/sbin",
+    "/usr/local/bin",
+    "/usr/local/sbin",
+    "/usr/bin",
+    "/bin",
+    "/usr/sbin",
+    "/sbin",
+)
+
+
+def get_cli_agent_search_path(path: str | None = None) -> str:
+    current = os.environ.get("PATH") if path is None else path
+    if current == "":
+        return ""
+    entries = [entry for entry in (current or os.defpath).split(os.pathsep) if entry]
+    home = Path.home()
+    entries.extend(
+        [
+            str(home / ".local/bin"),
+            str(home / "bin"),
+            str(home / ".cargo/bin"),
+            str(home / ".volta/bin"),
+        ]
+    )
+    entries.extend(GUI_APP_PATHS)
+    return os.pathsep.join(dict.fromkeys(entries))
+
+
+def resolve_cli_agent_path(executable: str, path: str | None = None) -> str:
+    return shutil.which(executable, path=get_cli_agent_search_path(path)) or ""
 
 
 def load_cli_agent_script(config_root: Path, executable_info_file: str) -> str:

--- a/guildbotics/app_api/diagnostics.py
+++ b/guildbotics/app_api/diagnostics.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-import os
-import shutil
 import tempfile
 from pathlib import Path
 from typing import Any, Literal, cast
 
-from guildbotics.app_api.cli_agents import resolve_default_cli_executable
+from guildbotics.app_api.cli_agents import (
+    resolve_cli_agent_path,
+    resolve_default_cli_executable,
+)
 from guildbotics.app_api.models import DiagnosticCheck, ScenarioDiagnosticsResponse
 from guildbotics.entities.message import Message
 from guildbotics.entities.team import Person, Service
@@ -176,8 +177,8 @@ class ScenarioDiagnosticsService:
                 )
             ]
 
-        path = shutil.which(executable, path=os.environ.get("PATH"))
-        if path is None:
+        path = resolve_cli_agent_path(executable)
+        if not path:
             return [
                 self._check(
                     "cli_agent",

--- a/guildbotics/app_api/diagnostics.py
+++ b/guildbotics/app_api/diagnostics.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import tempfile
 from pathlib import Path
 from typing import Any, Literal, cast
@@ -9,6 +10,10 @@ from guildbotics.app_api.cli_agents import (
     resolve_default_cli_executable,
 )
 from guildbotics.app_api.models import DiagnosticCheck, ScenarioDiagnosticsResponse
+from guildbotics.app_api.verify import (
+    PROVIDER_ENV_KEYS,
+    resolve_default_model_provider,
+)
 from guildbotics.entities.message import Message
 from guildbotics.entities.team import Person, Service
 from guildbotics.integrations.chat_profile import get_chat_subscriptions
@@ -129,6 +134,25 @@ class ScenarioDiagnosticsService:
     async def _check_llm(
         self, context: Context, member: Person
     ) -> list[DiagnosticCheck]:
+        # Short-circuit BEFORE firing a live LLM call when the provider's API
+        # key is not configured. Without this gate the diagnostics journey
+        # depends on external network availability and provider latency, which
+        # conflicts with the repo's "no external service calls in tests"
+        # policy. The static verify check has long behaved this way; the
+        # scenario diagnostics now match.
+        provider = resolve_default_model_provider()
+        env_key = PROVIDER_ENV_KEYS.get(provider)
+        if env_key is not None and not os.environ.get(env_key):
+            return [
+                self._check(
+                    "llm",
+                    "llm_api_key",
+                    "error",
+                    f"{env_key} is not configured; skipping live LLM call.",
+                    person_id=member.person_id,
+                    context={"provider": provider, "env_key": env_key},
+                )
+            ]
         c = context.clone_for(member)
         try:
             messages = [

--- a/guildbotics/app_api/intelligences.py
+++ b/guildbotics/app_api/intelligences.py
@@ -4,6 +4,7 @@ import shutil
 from pathlib import Path
 from typing import Any, cast
 
+from guildbotics.app_api.cli_agents import resolve_cli_agent_path
 from guildbotics.app_api.models import (
     BrainAssignment,
     CliAgentDefinition,
@@ -218,7 +219,7 @@ class IntelligenceConfigService:
                 env = {}
             name = agent_path.removesuffix(".yml")
             executable = name.removesuffix("-cli")
-            detected_path = shutil.which(executable) or ""
+            detected_path = resolve_cli_agent_path(executable)
             agents.append(
                 CliAgentDefinition(
                     path=agent_path,

--- a/guildbotics/app_api/runtime.py
+++ b/guildbotics/app_api/runtime.py
@@ -6,7 +6,6 @@ import logging
 import os
 import re
 import shlex
-import shutil
 import threading
 import uuid
 from collections.abc import Iterator
@@ -18,6 +17,7 @@ from dotenv import dotenv_values, load_dotenv
 from guildbotics.app_api.cli_agents import (
     CLI_AGENT_EXECUTABLES,
     load_cli_agent_script,
+    resolve_cli_agent_path,
     resolve_cli_executable,
 )
 from guildbotics.app_api.diagnostics import ScenarioDiagnosticsService
@@ -418,17 +418,13 @@ class AppRuntime:
             executable_info_file = str(mapping.get(name, ""))
             script = load_cli_agent_script(get_template_path(), executable_info_file)
             executable = resolve_cli_executable(script)
-            path = (
-                shutil.which(executable, path=os.environ.get("PATH"))
-                if executable
-                else None
-            )
+            path = resolve_cli_agent_path(executable) if executable else ""
             agents.append(
                 CliAgentDetection(
                     name=name,
                     executable=executable,
-                    detected=path is not None,
-                    path=path or "",
+                    detected=bool(path),
+                    path=path,
                 )
             )
         return CliAgentDetectionsResponse(agents=agents)
@@ -940,7 +936,9 @@ def _requirement_satisfied(kind: str, github_enabled: bool) -> bool:
             or os.getenv("ANTHROPIC_API_KEY")
         )
     if kind == "cli_agent":
-        return any(shutil.which(executable) for executable in CLI_AGENT_EXECUTABLES)
+        return any(
+            resolve_cli_agent_path(executable) for executable in CLI_AGENT_EXECUTABLES
+        )
     return True
 
 

--- a/guildbotics/app_api/verify.py
+++ b/guildbotics/app_api/verify.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
 import os
-import shutil
 from pathlib import Path
 from typing import Any, cast
 
 from dotenv import dotenv_values
 
-from guildbotics.app_api.cli_agents import resolve_default_cli_executable
+from guildbotics.app_api.cli_agents import (
+    resolve_cli_agent_path,
+    resolve_default_cli_executable,
+)
 from guildbotics.app_api.models import ConfigStatus, VerifyCheck, VerifyResponse
 from guildbotics.entities.team import Person, Service, Team
 from guildbotics.integrations.github.github_utils import GitHubAppAuth
@@ -160,11 +162,12 @@ class VerifyService:
                 )
             ]
 
-        path = shutil.which(executable, path=env.get("PATH") or os.environ.get("PATH"))
+        search_path = env.get("PATH")
+        path = resolve_cli_agent_path(executable, search_path)
         return [
             self._check(
                 "cli_agent_executable",
-                path is not None,
+                bool(path),
                 f"CLI agent executable '{executable}' was found.",
                 f"CLI agent executable '{executable}' was not found on PATH.",
                 target=executable,

--- a/guildbotics/app_api/verify.py
+++ b/guildbotics/app_api/verify.py
@@ -15,6 +15,39 @@ from guildbotics.entities.team import Person, Service, Team
 from guildbotics.integrations.github.github_utils import GitHubAppAuth
 from guildbotics.utils.fileio import get_config_path, load_yaml_file
 
+PROVIDER_ENV_KEYS: dict[str, str] = {
+    "openai": "OPENAI_API_KEY",
+    "gemini": "GOOGLE_API_KEY",
+    "google": "GOOGLE_API_KEY",
+    "anthropic": "ANTHROPIC_API_KEY",
+}
+
+
+def resolve_default_model_provider() -> str:
+    """Return the default LLM provider name from the team's intelligence config.
+
+    Returns an empty string when the mapping cannot be parsed or the default
+    model does not match a known provider. Shared with the scenario diagnostics
+    service so missing-key short-circuits stay consistent with the static
+    verify checks.
+    """
+    try:
+        mapping = cast(
+            dict[str, Any],
+            load_yaml_file(get_config_path("intelligences/model_mapping.yml")),
+        )
+        default_model = str(mapping.get("default", ""))
+        if "openai" in default_model:
+            return "openai"
+        if "gemini" in default_model or "google" in default_model:
+            return "gemini"
+        if "anthropic" in default_model or "claude" in default_model:
+            return "anthropic"
+    except Exception:
+        pass
+
+    return ""
+
 
 class VerifyService:
     def verify(
@@ -123,12 +156,7 @@ class VerifyService:
         self, team: Team, env: dict[str, str | None]
     ) -> list[VerifyCheck]:
         provider = self._resolve_default_model_provider(team)
-        key = {
-            "openai": "OPENAI_API_KEY",
-            "gemini": "GOOGLE_API_KEY",
-            "google": "GOOGLE_API_KEY",
-            "anthropic": "ANTHROPIC_API_KEY",
-        }.get(provider)
+        key = PROVIDER_ENV_KEYS.get(provider)
 
         if key is None:
             return [
@@ -216,22 +244,10 @@ class VerifyService:
         return []
 
     def _resolve_default_model_provider(self, team: Team) -> str:
-        try:
-            mapping = cast(
-                dict[str, Any],
-                load_yaml_file(get_config_path("intelligences/model_mapping.yml")),
-            )
-            default_model = str(mapping.get("default", ""))
-            if "openai" in default_model:
-                return "openai"
-            if "gemini" in default_model or "google" in default_model:
-                return "gemini"
-            if "anthropic" in default_model or "claude" in default_model:
-                return "anthropic"
-        except Exception:
-            pass
-
-        return ""
+        # The team parameter is retained for API stability; provider resolution
+        # only depends on the workspace intelligence mapping.
+        del team
+        return resolve_default_model_provider()
 
     def _resolve_default_cli_executable(self) -> str:
         return resolve_default_cli_executable()

--- a/guildbotics/intelligences/brains/cli_agent.py
+++ b/guildbotics/intelligences/brains/cli_agent.py
@@ -10,6 +10,7 @@ from typing import Any, cast
 
 from pydantic import BaseModel
 
+from guildbotics.app_api.cli_agents import get_cli_agent_search_path
 from guildbotics.intelligences.brains.brain import Brain
 from guildbotics.intelligences.brains.util import to_plain_text, to_response_class
 from guildbotics.intelligences.common import AgentResponse
@@ -224,7 +225,7 @@ class CliAgentBrain(Brain):
         """
         # Merge provided env with current environment
         env = (self.executable_info.env or {}).copy()
-        env["PATH"] = os.environ.get("PATH", "")
+        env["PATH"] = get_cli_agent_search_path()
         xdg_runtime_dir = os.environ.get("XDG_RUNTIME_DIR")
         if xdg_runtime_dir:
             env["XDG_RUNTIME_DIR"] = xdg_runtime_dir

--- a/scripts/desktop-build-all.sh
+++ b/scripts/desktop-build-all.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+"$SCRIPT_DIR/desktop-build-backend.sh"
+"$SCRIPT_DIR/desktop-build-frontend.sh"

--- a/scripts/desktop-build-backend.sh
+++ b/scripts/desktop-build-backend.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)"
+DESKTOP_TARGET="${DESKTOP_TARGET:-aarch64-apple-darwin}"
+SIDECAR_NAME="guildbotics-app-api-${DESKTOP_TARGET}"
+
+cd "$REPO_ROOT"
+
+uv sync --extra test --extra dev
+
+uv run --with pyinstaller python -m PyInstaller \
+  desktop/sidecar/guildbotics-app-api.spec \
+  --noconfirm --clean \
+  --distpath dist --workpath build/sidecar
+
+mkdir -p desktop/src-tauri/binaries
+cp dist/guildbotics-app-api "desktop/src-tauri/binaries/${SIDECAR_NAME}"
+chmod +x "desktop/src-tauri/binaries/${SIDECAR_NAME}"
+
+echo "Built backend sidecar: desktop/src-tauri/binaries/${SIDECAR_NAME}"

--- a/scripts/desktop-build-frontend.sh
+++ b/scripts/desktop-build-frontend.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)"
+DESKTOP_TARGET="${DESKTOP_TARGET:-aarch64-apple-darwin}"
+SIDECAR_PATH="$REPO_ROOT/desktop/src-tauri/binaries/guildbotics-app-api-${DESKTOP_TARGET}"
+
+if [[ ! -x "$SIDECAR_PATH" ]]; then
+  echo "Missing executable backend sidecar: $SIDECAR_PATH" >&2
+  echo "Run scripts/desktop-build-backend.sh first, or set DESKTOP_TARGET." >&2
+  exit 1
+fi
+
+cd "$REPO_ROOT/desktop"
+
+npm install
+npm run tauri build -- --target "$DESKTOP_TARGET"

--- a/scripts/desktop-dev-all.sh
+++ b/scripts/desktop-dev-all.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+HOST="${GUILDBOTICS_APP_API_HOST:-127.0.0.1}"
+PORT="${GUILDBOTICS_APP_API_PORT:-8765}"
+TOKEN="${GUILDBOTICS_APP_API_TOKEN:-dev-token}"
+BASE_URL="http://${HOST}:${PORT}"
+
+"$SCRIPT_DIR/desktop-dev-backend.sh" &
+BACKEND_PID=$!
+
+cleanup() {
+  kill "$BACKEND_PID" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+for _ in {1..150}; do
+  if curl -fsS -H "X-GuildBotics-Session-Token: ${TOKEN}" \
+    "${BASE_URL}/health" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.3
+done
+
+if ! curl -fsS -H "X-GuildBotics-Session-Token: ${TOKEN}" \
+  "${BASE_URL}/health" >/dev/null 2>&1; then
+  echo "Backend did not become healthy: ${BASE_URL}" >&2
+  exit 1
+fi
+
+"$SCRIPT_DIR/desktop-dev-frontend.sh"

--- a/scripts/desktop-dev-backend.sh
+++ b/scripts/desktop-dev-backend.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)"
+
+HOST="${GUILDBOTICS_APP_API_HOST:-127.0.0.1}"
+PORT="${GUILDBOTICS_APP_API_PORT:-8765}"
+TOKEN="${GUILDBOTICS_APP_API_TOKEN:-dev-token}"
+
+cd "$REPO_ROOT"
+
+if command -v uv >/dev/null 2>&1; then
+  exec uv run --no-sync python -m guildbotics.app_api \
+    --host "$HOST" --port "$PORT" --token "$TOKEN"
+fi
+
+exec python3 -m guildbotics.app_api \
+  --host "$HOST" --port "$PORT" --token "$TOKEN"

--- a/scripts/desktop-dev-frontend.sh
+++ b/scripts/desktop-dev-frontend.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)"
+
+HOST="${GUILDBOTICS_APP_API_HOST:-127.0.0.1}"
+PORT="${GUILDBOTICS_APP_API_PORT:-8765}"
+TOKEN="${GUILDBOTICS_APP_API_TOKEN:-dev-token}"
+
+cd "$REPO_ROOT/desktop"
+
+if [[ ! -d node_modules ]]; then
+  npm install
+fi
+
+VITE_GUILDBOTICS_API_TOKEN="$TOKEN" \
+  VITE_GUILDBOTICS_API_BASE="http://${HOST}:${PORT}" \
+  npm run dev

--- a/tests/guildbotics/app_api/test_api.py
+++ b/tests/guildbotics/app_api/test_api.py
@@ -29,15 +29,30 @@ from guildbotics.app_api.models import (
     VerifyResponse,
 )
 from guildbotics.app_api.runtime import AppRuntime
+from guildbotics.editions.simple.setup_service import (
+    GitHubUserReference,
+    SetupServiceError,
+    SimplePersonSetupService,
+    SimpleProjectSetupService,
+)
 
 HTTP_OK = 200
 HTTP_BAD_REQUEST = 400
 HTTP_UNAUTHORIZED = 401
 HTTP_UNPROCESSABLE_ENTITY = 422
+HTTP_INTERNAL_SERVER_ERROR = 500
 HTTP_CONFLICT = 409
 THREAD_WAIT_SECONDS = 2.0
 DEFAULT_MAX_CONSECUTIVE_ERRORS = 3
 DEFAULT_ROUTINE_INTERVAL_MINUTES = 10
+GITHUB_APPS_USER_ID = 42
+
+AUTH_HEADERS = {"X-GuildBotics-Session-Token": "secret"}
+
+
+def _client(runtime: "RuntimeStub") -> TestClient:
+    """Build a TestClient bound to a stubbed runtime with a fixed token."""
+    return TestClient(create_app(session_token="secret", runtime=runtime))
 
 
 def _runtime_status(
@@ -1693,3 +1708,520 @@ async def test_app_runtime_rejects_parallel_commands(monkeypatch) -> None:
         "command.finished",
     ]
     assert all(event["request_id"] == response.request_id for event in events)
+
+
+# --- auth coverage -------------------------------------------------------
+
+
+PROTECTED_ENDPOINTS = [
+    ("GET", "/health"),
+    ("GET", "/config/status"),
+    ("POST", "/workspace"),
+    ("GET", "/team"),
+    ("GET", "/commands/options"),
+    ("POST", "/commands/run"),
+    ("GET", "/config/roles"),
+    ("GET", "/scheduler/routines"),
+    ("GET", "/scheduler/status"),
+    ("POST", "/scheduler/start"),
+    ("POST", "/scheduler/stop"),
+    ("GET", "/prompt-trace"),
+    ("PUT", "/prompt-trace"),
+    ("POST", "/verify"),
+    ("POST", "/diagnostics/scenario"),
+    ("GET", "/intelligences/cli-agents/detection"),
+    ("GET", "/config/intelligences"),
+    ("PUT", "/config/intelligences"),
+    ("POST", "/config/init"),
+    ("GET", "/config/project"),
+    ("PUT", "/config/project"),
+    ("POST", "/config/members"),
+    ("GET", "/config/members/alice"),
+    ("PUT", "/config/members/alice"),
+    ("DELETE", "/config/members/alice"),
+    ("POST", "/config/members/resolve"),
+]
+
+
+@pytest.mark.parametrize("method,path", PROTECTED_ENDPOINTS)
+@pytest.mark.parametrize("headers", [None, {"X-GuildBotics-Session-Token": "wrong"}])
+def test_every_endpoint_rejects_missing_or_invalid_token(
+    tmp_path: Path, method: str, path: str, headers: dict[str, str] | None
+) -> None:
+    client = _client(RuntimeStub(tmp_path))
+
+    response = client.request(method, path, headers=headers, json={})
+
+    assert response.status_code == HTTP_UNAUTHORIZED
+    assert response.json() == {
+        "code": "invalid_session_token",
+        "message": "Invalid session token.",
+        "context": {},
+    }
+
+
+def test_unexpected_error_maps_to_internal_error(tmp_path: Path) -> None:
+    class BoomStub(RuntimeStub):
+        def get_team_summary(self) -> TeamSummary:
+            raise RuntimeError("boom")
+
+    client = TestClient(
+        create_app(session_token="secret", runtime=BoomStub(tmp_path)),
+        raise_server_exceptions=False,
+    )
+
+    response = client.get("/team", headers=AUTH_HEADERS)
+
+    assert response.status_code == HTTP_INTERNAL_SERVER_ERROR
+    assert response.json() == {
+        "code": "internal_error",
+        "message": "An unexpected app API error occurred.",
+        "context": {"error_type": "RuntimeError"},
+    }
+
+
+# --- config / workspace --------------------------------------------------
+
+
+def test_workspace_change_rejects_missing_directory(tmp_path: Path) -> None:
+    missing = tmp_path / "nope"
+    client = TestClient(
+        create_app(session_token="secret", runtime=AppRuntime(EventBus()))
+    )
+
+    response = client.post(
+        "/workspace",
+        headers=AUTH_HEADERS,
+        json={"workspace_dir": str(missing)},
+    )
+
+    assert response.status_code == HTTP_BAD_REQUEST
+    payload = response.json()
+    assert payload["code"] == "workspace_not_found"
+    assert payload["context"]["workspace_dir"] == str(missing.resolve())
+
+
+def test_workspace_change_rejects_non_directory(tmp_path: Path) -> None:
+    file_path = tmp_path / "file.txt"
+    file_path.write_text("hello")
+    client = TestClient(
+        create_app(session_token="secret", runtime=AppRuntime(EventBus()))
+    )
+
+    response = client.post(
+        "/workspace",
+        headers=AUTH_HEADERS,
+        json={"workspace_dir": str(file_path)},
+    )
+
+    assert response.status_code == HTTP_BAD_REQUEST
+    payload = response.json()
+    assert payload["code"] == "workspace_not_directory"
+    assert payload["context"]["workspace_dir"] == str(file_path.resolve())
+
+
+def test_config_roles_rejects_invalid_language(tmp_path: Path) -> None:
+    client = _client(RuntimeStub(tmp_path))
+
+    response = client.get("/config/roles?language=fr", headers=AUTH_HEADERS)
+
+    assert response.status_code == HTTP_UNPROCESSABLE_ENTITY
+    payload = response.json()
+    assert payload["code"] == "validation_error"
+    assert isinstance(payload["context"]["errors"], list)
+
+
+def test_config_init_maps_setup_service_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    client = _client(RuntimeStub(tmp_path))
+
+    def _boom(self: SimpleProjectSetupService, request: Any) -> Any:
+        raise SetupServiceError("project_invalid", "Project config is invalid.")
+
+    monkeypatch.setattr(
+        "guildbotics.app_api.api.SimpleProjectSetupService.write_project", _boom
+    )
+
+    response = client.post(
+        "/config/init",
+        headers=AUTH_HEADERS,
+        json={
+            "config_dir": str(tmp_path / ".guildbotics/config"),
+            "env_file_path": str(tmp_path / ".env"),
+            "env_file_option": "overwrite",
+            "language": "en",
+            "description": "desc",
+            "llm_api_type": "openai",
+            "cli_agent": "codex",
+            "openai_api_key": "k",
+        },
+    )
+
+    assert response.status_code == HTTP_BAD_REQUEST
+    assert response.json() == {
+        "code": "project_invalid",
+        "message": "Project config is invalid.",
+        "context": {},
+    }
+
+
+def test_config_project_get_reports_project_not_found(tmp_path: Path) -> None:
+    client = _client(RuntimeStub(tmp_path))
+
+    response = client.get("/config/project", headers=AUTH_HEADERS)
+
+    assert response.status_code == HTTP_BAD_REQUEST
+    payload = response.json()
+    assert payload["code"] == "project_not_found"
+    assert "primary" in payload["context"]
+    assert "home" in payload["context"]
+
+
+def test_config_project_update_maps_setup_service_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    client = _client(RuntimeStub(tmp_path))
+
+    def _boom(self: SimpleProjectSetupService, request: Any) -> Any:
+        raise SetupServiceError("project_invalid", "Project config is invalid.")
+
+    monkeypatch.setattr(
+        "guildbotics.app_api.api.SimpleProjectSetupService.update_project", _boom
+    )
+
+    response = client.put(
+        "/config/project",
+        headers=AUTH_HEADERS,
+        json={
+            "config_dir": str(tmp_path / ".guildbotics/config"),
+            "env_file_path": str(tmp_path / ".env"),
+            "language": "en",
+            "description": "desc",
+            "llm_api_type": "openai",
+            "cli_agent": "codex",
+            "github_enabled": False,
+        },
+    )
+
+    assert response.status_code == HTTP_BAD_REQUEST
+    assert response.json()["code"] == "project_invalid"
+
+
+# --- members -------------------------------------------------------------
+
+
+def test_member_config_get_reports_project_not_found(tmp_path: Path) -> None:
+    client = _client(RuntimeStub(tmp_path))
+
+    response = client.get("/config/members/alice", headers=AUTH_HEADERS)
+
+    assert response.status_code == HTTP_BAD_REQUEST
+    assert response.json()["code"] == "project_not_found"
+
+
+def test_member_update_rejects_person_id_mismatch(tmp_path: Path) -> None:
+    client = _client(RuntimeStub(tmp_path))
+
+    response = client.put(
+        "/config/members/alice",
+        headers=AUTH_HEADERS,
+        json={
+            "config_dir": str(tmp_path / ".guildbotics/config"),
+            "env_file_path": str(tmp_path / ".env"),
+            "original_person_id": "bob",
+            "person_type": "machine_user",
+            "person_id": "alice",
+            "person_name": "Alice",
+            "is_active": True,
+            "github_username": "alice",
+            "git_email": "1+alice@users.noreply.github.com",
+            "roles": ["architect"],
+        },
+    )
+
+    assert response.status_code == HTTP_BAD_REQUEST
+    assert response.json() == {
+        "code": "person_id_mismatch",
+        "message": "original_person_id must match the path parameter.",
+        "context": {},
+    }
+
+
+def test_members_resolve_github_apps_url_branch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    client = _client(RuntimeStub(tmp_path))
+    captured: dict[str, Any] = {}
+
+    def _parse(self: SimplePersonSetupService, url: str) -> str:
+        captured["url"] = url
+        return "my-app"
+
+    def _resolve(
+        self: SimplePersonSetupService, identity: str, is_github_apps: bool = False
+    ) -> GitHubUserReference:
+        captured["identity"] = identity
+        captured["is_github_apps"] = is_github_apps
+        return GitHubUserReference(
+            person_id="my-app",
+            github_username="my-app[bot]",
+            github_user_id=GITHUB_APPS_USER_ID,
+            git_email="42+my-app[bot]@users.noreply.github.com",
+        )
+
+    monkeypatch.setattr(
+        "guildbotics.app_api.api.SimplePersonSetupService.parse_github_apps_url",
+        _parse,
+    )
+    monkeypatch.setattr(
+        "guildbotics.app_api.api.SimplePersonSetupService.resolve_github_user",
+        _resolve,
+    )
+
+    response = client.post(
+        "/config/members/resolve",
+        headers=AUTH_HEADERS,
+        json={
+            "person_type": "github_apps",
+            "identity": "https://github.com/apps/my-app",
+        },
+    )
+
+    assert response.status_code == HTTP_OK
+    assert captured == {
+        "url": "https://github.com/apps/my-app",
+        "identity": "my-app",
+        "is_github_apps": True,
+    }
+    assert response.json()["github_username"] == "my-app[bot]"
+    assert response.json()["github_user_id"] == GITHUB_APPS_USER_ID
+
+
+def test_members_resolve_maps_setup_service_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    client = _client(RuntimeStub(tmp_path))
+
+    def _boom(
+        self: SimplePersonSetupService, identity: str, is_github_apps: bool = False
+    ) -> GitHubUserReference:
+        raise SetupServiceError("github_user_not_found", "GitHub user not found.")
+
+    monkeypatch.setattr(
+        "guildbotics.app_api.api.SimplePersonSetupService.resolve_github_user",
+        _boom,
+    )
+
+    response = client.post(
+        "/config/members/resolve",
+        headers=AUTH_HEADERS,
+        json={"person_type": "machine_user", "identity": "ghost"},
+    )
+
+    assert response.status_code == HTTP_BAD_REQUEST
+    assert response.json() == {
+        "code": "github_user_not_found",
+        "message": "GitHub user not found.",
+        "context": {},
+    }
+
+
+# --- intelligences -------------------------------------------------------
+
+
+def test_config_intelligences_reports_project_not_found(tmp_path: Path) -> None:
+    client = _client(RuntimeStub(tmp_path))
+
+    response = client.get("/config/intelligences", headers=AUTH_HEADERS)
+
+    assert response.status_code == HTTP_BAD_REQUEST
+    assert response.json()["code"] == "project_not_found"
+
+
+def test_config_intelligences_update_maps_setup_service_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    client = _client(RuntimeStub(tmp_path))
+
+    def _boom(self: Any, request: Any) -> Any:
+        raise SetupServiceError("intelligence_invalid", "Intelligence config invalid.")
+
+    monkeypatch.setattr(
+        "guildbotics.app_api.api.IntelligenceConfigService.update_config", _boom
+    )
+
+    response = client.put(
+        "/config/intelligences",
+        headers=AUTH_HEADERS,
+        json={"config_dir": str(tmp_path / ".guildbotics/config")},
+    )
+
+    assert response.status_code == HTTP_BAD_REQUEST
+    assert response.json() == {
+        "code": "intelligence_invalid",
+        "message": "Intelligence config invalid.",
+        "context": {},
+    }
+
+
+# --- scheduler -----------------------------------------------------------
+
+
+def test_scheduler_start_only_scheduler_endpoint(tmp_path: Path) -> None:
+    client = _client(RuntimeStub(tmp_path))
+
+    response = client.post(
+        "/scheduler/start",
+        headers=AUTH_HEADERS,
+        json={"only": "scheduler"},
+    )
+
+    assert response.status_code == HTTP_OK
+    assert response.json()["scheduler"]["state"] == "running"
+    assert response.json()["events"]["state"] == "running"
+
+
+def test_scheduler_start_both_endpoint(tmp_path: Path) -> None:
+    client = _client(RuntimeStub(tmp_path))
+
+    response = client.post("/scheduler/start", headers=AUTH_HEADERS, json={})
+
+    assert response.status_code == HTTP_OK
+    assert response.json()["scheduler"]["state"] == "running"
+    assert response.json()["events"]["state"] == "running"
+
+
+def test_scheduler_start_rejects_github_required_routine(tmp_path: Path) -> None:
+    class RejectingStub(RuntimeStub):
+        def start_scheduler(self, request: Any) -> RuntimeStatus:
+            raise AppApiError(
+                "github_integration_required_for_routine",
+                "GitHub integration is required for this routine.",
+                context={"routine_commands": list(request.routine_commands)},
+            )
+
+    client = _client(RejectingStub(tmp_path))
+
+    response = client.post(
+        "/scheduler/start",
+        headers=AUTH_HEADERS,
+        json={"routine_commands": ["workflows/ticket_driven_workflow"]},
+    )
+
+    assert response.status_code == HTTP_BAD_REQUEST
+    payload = response.json()
+    assert payload["code"] == "github_integration_required_for_routine"
+    assert payload["context"]["routine_commands"] == [
+        "workflows/ticket_driven_workflow"
+    ]
+
+
+def test_scheduler_stop_endpoint(tmp_path: Path) -> None:
+    client = _client(RuntimeStub(tmp_path))
+
+    response = client.post("/scheduler/stop", headers=AUTH_HEADERS)
+
+    assert response.status_code == HTTP_OK
+    assert response.json()["scheduler"]["state"] == "stopped"
+    assert response.json()["events"]["state"] == "stopped"
+
+
+# --- prompt trace --------------------------------------------------------
+
+
+@pytest.mark.parametrize("limit", [0, 1001])
+def test_prompt_trace_get_rejects_out_of_range_limit(
+    tmp_path: Path, limit: int
+) -> None:
+    client = _client(RuntimeStub(tmp_path))
+
+    response = client.get(
+        "/prompt-trace", headers=AUTH_HEADERS, params={"limit": limit}
+    )
+
+    assert response.status_code == HTTP_UNPROCESSABLE_ENTITY
+    assert response.json()["code"] == "validation_error"
+
+
+@pytest.mark.parametrize("limit", [0, 1001])
+def test_prompt_trace_put_rejects_out_of_range_limit(
+    tmp_path: Path, limit: int
+) -> None:
+    client = _client(RuntimeStub(tmp_path))
+
+    response = client.put(
+        "/prompt-trace",
+        headers=AUTH_HEADERS,
+        params={"limit": limit},
+        json={"enabled": True},
+    )
+
+    assert response.status_code == HTTP_UNPROCESSABLE_ENTITY
+    assert response.json()["code"] == "validation_error"
+
+
+# --- commands ------------------------------------------------------------
+
+
+def test_command_options_reports_person_not_found(tmp_path: Path) -> None:
+    class PersonStub(RuntimeStub):
+        def get_command_options(
+            self, person: str | None = None
+        ) -> CommandOptionsResponse:
+            raise AppApiError(
+                "person_not_found",
+                "Member not found.",
+                context={"person": person},
+            )
+
+    client = _client(PersonStub(tmp_path))
+
+    response = client.get(
+        "/commands/options", headers=AUTH_HEADERS, params={"person": "ghost"}
+    )
+
+    assert response.status_code == HTTP_BAD_REQUEST
+    assert response.json() == {
+        "code": "person_not_found",
+        "message": "Member not found.",
+        "context": {"person": "ghost"},
+    }
+
+
+def test_command_run_conflict_returns_409(tmp_path: Path) -> None:
+    class ConflictStub(RuntimeStub):
+        async def run_command(self, request: Any) -> Any:
+            raise AppApiError(
+                "command_already_running",
+                "A command is already running.",
+                status_code=HTTP_CONFLICT,
+            )
+
+    client = _client(ConflictStub(tmp_path))
+
+    response = client.post(
+        "/commands/run", headers=AUTH_HEADERS, json={"command": "hello"}
+    )
+
+    assert response.status_code == HTTP_CONFLICT
+    assert response.json() == {
+        "code": "command_already_running",
+        "message": "A command is already running.",
+        "context": {},
+    }
+
+
+# --- diagnostics ---------------------------------------------------------
+
+
+def test_verify_endpoint_uses_runtime(tmp_path: Path) -> None:
+    client = _client(RuntimeStub(tmp_path))
+
+    response = client.post("/verify", headers=AUTH_HEADERS)
+
+    assert response.status_code == HTTP_OK
+    payload = response.json()
+    assert payload["ok"] is False
+    assert payload["errors"][0]["code"] == "active_members"
+    assert payload["checks"][0]["status"] == "error"

--- a/tests/guildbotics/app_api/test_api_integration.py
+++ b/tests/guildbotics/app_api/test_api_integration.py
@@ -1,0 +1,217 @@
+"""End-to-end integration tests against a real temporary workspace.
+
+Unlike ``test_api.py`` (which drives a stubbed runtime), these tests build a
+real :class:`AppRuntime` whose working directory is a ``tmp_path`` workspace.
+They exercise the FastAPI app via ``TestClient`` and assert that requests
+actually create / read / update files on disk.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from yaml import safe_load
+
+from guildbotics.app_api.api import create_app
+from guildbotics.app_api.events import EventBus
+from guildbotics.app_api.runtime import AppRuntime
+
+HTTP_OK = 200
+
+AUTH_HEADERS = {"X-GuildBotics-Session-Token": "secret"}
+
+
+@pytest.fixture
+def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A hermetic temp workspace acting as the runtime working directory."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("GUILDBOTICS_CONFIG_DIR", raising=False)
+    monkeypatch.delenv("GUILDBOTICS_PROMPT_TRACE", raising=False)
+    monkeypatch.delenv("GUILDBOTICS_PROMPT_TRACE_PATH", raising=False)
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+@pytest.fixture
+def client(workspace: Path) -> TestClient:
+    """A TestClient bound to a real runtime rooted at the temp workspace."""
+    app = create_app(session_token="secret", runtime=AppRuntime(EventBus()))
+    return TestClient(app)
+
+
+def _init_project(
+    client: TestClient,
+    config_dir: Path,
+    env_file: Path,
+    *,
+    language: str = "en",
+    description: str = "Temp automation workspace",
+) -> None:
+    response = client.post(
+        "/config/init",
+        headers=AUTH_HEADERS,
+        json={
+            "config_dir": str(config_dir),
+            "env_file_path": str(env_file),
+            "env_file_option": "overwrite",
+            "language": language,
+            "description": description,
+            "llm_api_type": "openai",
+            "cli_agent": "codex",
+            "openai_api_key": "test-openai-key",
+        },
+    )
+    assert response.status_code == HTTP_OK
+
+
+def test_temp_workspace_init_project_member_team_flow(
+    client: TestClient, workspace: Path
+) -> None:
+    config_dir = workspace / ".guildbotics/config"
+    env_file = workspace / ".env"
+
+    with client:
+        _init_project(client, config_dir, env_file)
+        # config/init wrote the project file on disk.
+        assert (config_dir / "team/project.yml").exists()
+
+        project = client.get("/config/project", headers=AUTH_HEADERS)
+        assert project.status_code == HTTP_OK
+        project_payload = project.json()
+        assert project_payload["language"] == "en"
+        assert project_payload["description"] == "Temp automation workspace"
+        assert project_payload["llm_api_type"] == "openai"
+        assert project_payload["has_openai_api_key"] is True
+        assert project_payload["github_enabled"] is False
+
+        member = client.post(
+            "/config/members",
+            headers=AUTH_HEADERS,
+            json={
+                "config_dir": str(config_dir),
+                "env_file_path": str(env_file),
+                "person_type": "",
+                "person_id": "local-agent",
+                "person_name": "Local Agent",
+                "is_active": True,
+                "github_username": "",
+                "git_email": "",
+                "roles": ["architect"],
+                "speaking_style": "concise",
+            },
+        )
+        assert member.status_code == HTTP_OK
+        assert (config_dir / "team/members/local-agent/person.yml").exists()
+
+        team = client.get("/team", headers=AUTH_HEADERS)
+
+    assert team.status_code == HTTP_OK
+    team_payload = team.json()
+    assert team_payload["project"]["language_code"] == "en"
+    members = team_payload["members"]
+    assert [entry["person_id"] for entry in members] == ["local-agent"]
+    assert members[0]["name"] == "Local Agent"
+    assert members[0]["is_active"] is True
+
+
+def test_temp_workspace_command_options_return_localized_sample_command(
+    client: TestClient, workspace: Path
+) -> None:
+    config_dir = workspace / ".guildbotics/config"
+    env_file = workspace / ".env"
+
+    with client:
+        _init_project(client, config_dir, env_file, language="ja")
+        response = client.get("/commands/options", headers=AUTH_HEADERS)
+
+    assert response.status_code == HTTP_OK
+    options = {option["command"]: option for option in response.json()["options"]}
+    # Sample commands were seeded into the otherwise-empty workspace.
+    assert {"translate", "summarize", "get-time-of-day", "context-info"} <= set(options)
+    # The seeded markdown file actually exists on disk.
+    assert (config_dir / "commands/translate.md").exists()
+    # The ja language code resolves the localized (.ja) description, not the
+    # English fallback, for the sample command.
+    translate = options["translate"]
+    assert translate["label"] == "Translate"
+    assert translate["description"] == "入力文を指定した2言語間で翻訳します。"
+
+
+def test_temp_workspace_intelligence_update_writes_files(
+    client: TestClient, workspace: Path
+) -> None:
+    config_dir = workspace / ".guildbotics/config"
+    env_file = workspace / ".env"
+
+    with client:
+        _init_project(client, config_dir, env_file)
+
+        current = client.get("/config/intelligences", headers=AUTH_HEADERS)
+        assert current.status_code == HTTP_OK
+        payload = current.json()
+        payload["model_mapping"]["default"] = "models/openai/gpt-5-mini.yml"
+
+        update = client.put(
+            "/config/intelligences",
+            headers=AUTH_HEADERS,
+            json={
+                "config_dir": str(config_dir),
+                "model_mapping": payload["model_mapping"],
+                "models": payload["models"],
+                "cli_agent_mapping": payload["cli_agent_mapping"],
+                "cli_agents": payload["cli_agents"],
+                "brain_mapping": payload["brain_mapping"],
+            },
+        )
+
+    assert update.status_code == HTTP_OK
+    written_files = {entry["path"] for entry in update.json()["intelligence"]["files"]}
+    model_mapping_file = config_dir / "intelligences/model_mapping.yml"
+    assert str(model_mapping_file) in written_files
+    # The file on disk reflects the requested change.
+    assert model_mapping_file.exists()
+    assert (
+        safe_load(model_mapping_file.read_text())["default"]
+        == "models/openai/gpt-5-mini.yml"
+    )
+    assert (config_dir / "intelligences/cli_agent_mapping.yml").exists()
+    assert (config_dir / "intelligences/brain_mapping.yml").exists()
+
+
+def test_temp_workspace_prompt_trace_update_then_status(
+    client: TestClient, workspace: Path
+) -> None:
+    config_dir = workspace / ".guildbotics/config"
+    env_file = workspace / ".env"
+    trace_file = workspace / "trace.jsonl"
+    trace_file.write_text(
+        '{"event":"llm.request","timestamp":"2026-06-01T12:00:00+09:00",'
+        '"person_id":"alice","brain":"default","message":"hello"}\n',
+        encoding="utf-8",
+    )
+
+    with client:
+        _init_project(client, config_dir, env_file)
+
+        update = client.put(
+            "/prompt-trace",
+            headers=AUTH_HEADERS,
+            json={"enabled": True, "trace_path": str(trace_file)},
+        )
+        assert update.status_code == HTTP_OK
+        assert update.json()["enabled"] is True
+        assert update.json()["trace_file"] == str(trace_file)
+
+        status = client.get("/prompt-trace", headers=AUTH_HEADERS)
+
+    assert status.status_code == HTTP_OK
+    status_payload = status.json()
+    assert status_payload["enabled"] is True
+    assert status_payload["trace_file"] == str(trace_file)
+    assert status_payload["event_count"] == 1
+    # The enabling flag was persisted to the workspace .env file.
+    assert "GUILDBOTICS_PROMPT_TRACE=1" in env_file.read_text()

--- a/tests/guildbotics/app_api/test_api_ws.py
+++ b/tests/guildbotics/app_api/test_api_ws.py
@@ -1,0 +1,202 @@
+"""Integration tests for the `/events` and `/logs` websocket endpoints.
+
+These tests exercise the real endpoint wiring in
+``guildbotics.app_api.api.create_app`` by driving the shared ``EventBus`` the
+same way the application does (publishing events/logs through the bus that is
+injected into the app). They assert concrete message payloads, the
+policy-violation close on a bad token, replayed history content, delivery to an
+already-connected client, and subscription cleanup after disconnect.
+"""
+
+import time
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+from guildbotics.app_api.api import create_app
+from guildbotics.app_api.events import EventBus
+
+POLICY_VIOLATION_CLOSE_CODE = 1008
+
+
+class RuntimeStub:
+    """Minimal runtime stub: websocket endpoints never touch it."""
+
+    def stop_scheduler(self) -> None:
+        return None
+
+
+def _app(event_bus: EventBus):
+    return create_app(
+        session_token="secret",
+        runtime=RuntimeStub(),
+        event_bus=event_bus,
+    )
+
+
+def test_events_success_receives_published_event(tmp_path: Path) -> None:
+    event_bus = EventBus()
+    app = _app(event_bus)
+
+    with (
+        TestClient(app) as client,
+        client.websocket_connect("/events?token=secret") as websocket,
+    ):
+        event_bus.publish_event(
+            "command.started",
+            {"command": "hello"},
+            request_id="request-live",
+        )
+        event = websocket.receive_json()
+
+    assert event["type"] == "command.started"
+    assert event["request_id"] == "request-live"
+    assert event["payload"] == {"command": "hello"}
+    assert event["timestamp"]
+
+
+def test_events_invalid_token_closes_with_policy_violation(tmp_path: Path) -> None:
+    event_bus = EventBus()
+    app = _app(event_bus)
+
+    with (
+        TestClient(app) as client,
+        pytest.raises(WebSocketDisconnect) as exc_info,
+        client.websocket_connect("/events?token=wrong") as websocket,
+    ):
+        websocket.receive_json()
+
+    assert exc_info.value.code == POLICY_VIOLATION_CLOSE_CODE
+    # No subscriber was ever registered for a rejected connection.
+    assert event_bus._event_subscribers == set()
+
+
+def test_logs_success_receives_published_log(tmp_path: Path) -> None:
+    event_bus = EventBus()
+    app = _app(event_bus)
+
+    with (
+        TestClient(app) as client,
+        client.websocket_connect("/logs?token=secret") as websocket,
+    ):
+        event_bus.publish_log("INFO", "scheduler started", request_id="log-live")
+        log = websocket.receive_json()
+
+    assert log["level"] == "INFO"
+    assert log["message"] == "scheduler started"
+    assert log["request_id"] == "log-live"
+    assert log["timestamp"]
+
+
+def test_logs_invalid_token_closes_with_policy_violation(tmp_path: Path) -> None:
+    event_bus = EventBus()
+    app = _app(event_bus)
+
+    with (
+        TestClient(app) as client,
+        pytest.raises(WebSocketDisconnect) as exc_info,
+        client.websocket_connect("/logs?token=wrong") as websocket,
+    ):
+        websocket.receive_json()
+
+    assert exc_info.value.code == POLICY_VIOLATION_CLOSE_CODE
+    assert event_bus._log_subscribers == set()
+
+
+def test_events_history_is_replayed_on_connect(tmp_path: Path) -> None:
+    event_bus = EventBus()
+    app = _app(event_bus)
+    # Publish before any client connects: the item must live in history.
+    event_bus.publish_event(
+        "command.finished",
+        {"output": "done"},
+        request_id="request-history",
+    )
+
+    with (
+        TestClient(app) as client,
+        client.websocket_connect("/events?token=secret") as websocket,
+    ):
+        replayed = websocket.receive_json()
+
+    assert replayed["type"] == "command.finished"
+    assert replayed["request_id"] == "request-history"
+    assert replayed["payload"] == {"output": "done"}
+
+
+def test_logs_history_is_replayed_on_connect(tmp_path: Path) -> None:
+    event_bus = EventBus()
+    app = _app(event_bus)
+    event_bus.publish_log("WARNING", "old log line", request_id="log-history")
+
+    with (
+        TestClient(app) as client,
+        client.websocket_connect("/logs?token=secret") as websocket,
+    ):
+        replayed = websocket.receive_json()
+
+    assert replayed["level"] == "WARNING"
+    assert replayed["message"] == "old log line"
+    assert replayed["request_id"] == "log-history"
+
+
+def test_events_history_then_live_delivery_in_order(tmp_path: Path) -> None:
+    event_bus = EventBus()
+    app = _app(event_bus)
+    event_bus.publish_event("command.started", {"command": "a"}, request_id="r1")
+
+    with (
+        TestClient(app) as client,
+        client.websocket_connect("/events?token=secret") as websocket,
+    ):
+        first = websocket.receive_json()
+        event_bus.publish_event("command.finished", {"command": "a"}, request_id="r1")
+        second = websocket.receive_json()
+
+    assert first["type"] == "command.started"
+    assert second["type"] == "command.finished"
+    assert [first["request_id"], second["request_id"]] == ["r1", "r1"]
+
+
+def test_disconnect_closes_event_subscription(tmp_path: Path) -> None:
+    event_bus = EventBus()
+    app = _app(event_bus)
+
+    with TestClient(app) as client:
+        with client.websocket_connect("/events?token=secret") as websocket:
+            event_bus.publish_event("command.started", {}, request_id="r1")
+            websocket.receive_json()
+            assert len(event_bus._event_subscribers) == 1
+
+        # After the context manager exits the client has disconnected; the
+        # endpoint's ``finally: queue.close()`` must drop the subscriber.
+        _wait_for_no_subscribers(event_bus._event_subscribers)
+
+    assert event_bus._event_subscribers == set()
+    # A further publish after disconnect must not raise.
+    event_bus.publish_event("command.finished", {}, request_id="r1")
+
+
+def test_disconnect_closes_log_subscription(tmp_path: Path) -> None:
+    event_bus = EventBus()
+    app = _app(event_bus)
+
+    with TestClient(app) as client:
+        with client.websocket_connect("/logs?token=secret") as websocket:
+            event_bus.publish_log("INFO", "hi", request_id="r1")
+            websocket.receive_json()
+            assert len(event_bus._log_subscribers) == 1
+
+        _wait_for_no_subscribers(event_bus._log_subscribers)
+
+    assert event_bus._log_subscribers == set()
+    event_bus.publish_log("INFO", "after disconnect", request_id="r1")
+
+
+def _wait_for_no_subscribers(subscribers: set, timeout: float = 2.0) -> None:
+    """Poll until the endpoint thread has run its cleanup, bounded by timeout."""
+    deadline = time.monotonic() + timeout
+    while subscribers and time.monotonic() < deadline:
+        time.sleep(0.01)

--- a/tests/guildbotics/app_api/test_cli_agents.py
+++ b/tests/guildbotics/app_api/test_cli_agents.py
@@ -1,0 +1,174 @@
+from pathlib import Path
+
+import pytest
+
+from guildbotics.app_api import cli_agents
+from guildbotics.app_api.cli_agents import (
+    get_cli_agent_search_path,
+    load_cli_agent_script,
+    resolve_cli_agent_path,
+    resolve_cli_executable,
+    resolve_default_cli_executable,
+)
+
+
+def test_cli_agent_search_path_preserves_explicit_empty_path() -> None:
+    assert get_cli_agent_search_path("") == ""
+
+
+def test_cli_agent_search_path_adds_gui_app_fallbacks() -> None:
+    path = get_cli_agent_search_path("/usr/bin:/bin")
+
+    entries = path.split(":")
+    assert entries[:2] == ["/usr/bin", "/bin"]
+    assert "/opt/homebrew/bin" in entries
+    assert "/usr/local/bin" in entries
+
+
+def test_cli_agent_search_path_deduplicates_entries(monkeypatch) -> None:
+    monkeypatch.setattr(cli_agents.Path, "home", lambda: Path("/home/tester"))
+
+    path = get_cli_agent_search_path("/usr/bin:/usr/bin:/opt/homebrew/bin")
+    entries = path.split(":")
+
+    assert entries.count("/usr/bin") == 1
+    assert entries.count("/opt/homebrew/bin") == 1
+
+
+def test_cli_agent_search_path_includes_user_bin_dirs(monkeypatch) -> None:
+    monkeypatch.setattr(cli_agents.Path, "home", lambda: Path("/home/tester"))
+
+    entries = get_cli_agent_search_path("/usr/bin").split(":")
+
+    assert "/home/tester/.local/bin" in entries
+    assert "/home/tester/bin" in entries
+    assert "/home/tester/.cargo/bin" in entries
+    assert "/home/tester/.volta/bin" in entries
+
+
+def test_cli_agent_search_path_falls_back_to_defpath_when_none(monkeypatch) -> None:
+    monkeypatch.setattr(cli_agents.os, "defpath", "/defpath/bin")
+    monkeypatch.delenv("PATH", raising=False)
+    monkeypatch.setattr(cli_agents.Path, "home", lambda: Path("/home/tester"))
+
+    entries = get_cli_agent_search_path(None).split(":")
+
+    assert "/defpath/bin" in entries
+
+
+def test_resolve_cli_agent_path_checks_user_bin(tmp_path: Path, monkeypatch) -> None:
+    bin_dir = tmp_path / ".local/bin"
+    bin_dir.mkdir(parents=True)
+    executable = bin_dir / "codex"
+    executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    executable.chmod(0o755)
+    monkeypatch.setattr(cli_agents.Path, "home", lambda: tmp_path)
+
+    assert resolve_cli_agent_path("codex", "/usr/bin") == str(executable)
+
+
+def test_resolve_cli_agent_path_returns_empty_when_missing(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(cli_agents.Path, "home", lambda: tmp_path)
+
+    assert resolve_cli_agent_path("does-not-exist", str(tmp_path)) == ""
+
+
+@pytest.mark.parametrize(
+    ("script", "expected"),
+    [
+        ("codex", "codex"),
+        ("codex exec", "codex"),
+        ("FOO=bar gemini --yolo", "gemini"),
+        ('claude "with quoted args"', "claude"),
+        ("npx copilot --print", "copilot"),
+        ("env CODEX_HOME=/tmp codex exec --json", "codex"),
+        ("", ""),
+        ("python run.py", ""),
+    ],
+)
+def test_resolve_cli_executable_parses_script(script: str, expected: str) -> None:
+    assert resolve_cli_executable(script) == expected
+
+
+def test_resolve_cli_executable_returns_first_match() -> None:
+    # CLI_AGENT_EXECUTABLES order is codex, gemini, claude, copilot.
+    assert resolve_cli_executable("codex then gemini") == "codex"
+    assert resolve_cli_executable("gemini then claude") == "gemini"
+
+
+def _write_agent(config_root: Path, name: str, body: str) -> None:
+    agent = config_root / "intelligences/cli_agents" / name
+    agent.parent.mkdir(parents=True, exist_ok=True)
+    agent.write_text(body, encoding="utf-8")
+
+
+def test_load_cli_agent_script_returns_script(tmp_path: Path) -> None:
+    _write_agent(tmp_path, "codex-cli.yml", "script: codex exec\n")
+
+    assert load_cli_agent_script(tmp_path, "codex-cli.yml") == "codex exec"
+
+
+def test_load_cli_agent_script_empty_info_file(tmp_path: Path) -> None:
+    assert load_cli_agent_script(tmp_path, "") == ""
+
+
+def test_load_cli_agent_script_missing_file(tmp_path: Path) -> None:
+    assert load_cli_agent_script(tmp_path, "missing.yml") == ""
+
+
+def test_load_cli_agent_script_malformed_yaml(tmp_path: Path) -> None:
+    _write_agent(tmp_path, "broken.yml", "script: codex exec\n  bad: : :\n")
+
+    assert load_cli_agent_script(tmp_path, "broken.yml") == ""
+
+
+def test_load_cli_agent_script_missing_script_key(tmp_path: Path) -> None:
+    _write_agent(tmp_path, "noscript.yml", "name: codex\n")
+
+    assert load_cli_agent_script(tmp_path, "noscript.yml") == ""
+
+
+def test_resolve_default_cli_executable_maps_mapping_to_executable(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("GUILDBOTICS_CONFIG_DIR", str(tmp_path))
+    mapping = tmp_path / "intelligences/cli_agent_mapping.yml"
+    mapping.parent.mkdir(parents=True, exist_ok=True)
+    mapping.write_text("default: gemini-cli.yml\n", encoding="utf-8")
+    _write_agent(tmp_path, "gemini-cli.yml", "script: gemini --yolo\n")
+
+    assert resolve_default_cli_executable() == "gemini"
+
+
+def test_resolve_default_cli_executable_maps_codex(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("GUILDBOTICS_CONFIG_DIR", str(tmp_path))
+    mapping = tmp_path / "intelligences/cli_agent_mapping.yml"
+    mapping.parent.mkdir(parents=True, exist_ok=True)
+    mapping.write_text("default: codex-cli.yml\n", encoding="utf-8")
+    _write_agent(tmp_path, "codex-cli.yml", "script: codex exec\n")
+
+    assert resolve_default_cli_executable() == "codex"
+
+
+def test_resolve_default_cli_executable_mapping_load_failure(monkeypatch) -> None:
+    def _raise(*_args, **_kwargs):
+        raise OSError("boom")
+
+    monkeypatch.setattr(cli_agents, "load_yaml_file", _raise)
+
+    assert resolve_default_cli_executable() == ""
+
+
+def test_resolve_default_cli_executable_missing_definition(
+    tmp_path: Path, monkeypatch
+) -> None:
+    # Mapping resolves but the referenced definition yields no script,
+    # so no executable can be inferred.
+    monkeypatch.setattr(
+        cli_agents, "load_yaml_file", lambda _file: {"default": "ghost-cli.yml"}
+    )
+    monkeypatch.setattr(cli_agents, "load_cli_agent_script", lambda *_a: "")
+
+    assert resolve_default_cli_executable() == ""

--- a/tests/guildbotics/app_api/test_cli_agents.py
+++ b/tests/guildbotics/app_api/test_cli_agents.py
@@ -16,6 +16,16 @@ def test_cli_agent_search_path_preserves_explicit_empty_path() -> None:
     assert get_cli_agent_search_path("") == ""
 
 
+def test_cli_agent_search_path_falls_back_for_ambient_empty_path(monkeypatch) -> None:
+    monkeypatch.setenv("PATH", "")
+
+    path = get_cli_agent_search_path()
+
+    entries = path.split(":")
+    assert "/usr/bin" in entries
+    assert "/opt/homebrew/bin" in entries
+
+
 def test_cli_agent_search_path_adds_gui_app_fallbacks() -> None:
     path = get_cli_agent_search_path("/usr/bin:/bin")
 

--- a/tests/guildbotics/app_api/test_diagnostics.py
+++ b/tests/guildbotics/app_api/test_diagnostics.py
@@ -1,0 +1,567 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from guildbotics.app_api import diagnostics as diagnostics_module
+from guildbotics.app_api.diagnostics import ScenarioDiagnosticsService
+from guildbotics.entities.team import (
+    MessageChannel,
+    Person,
+    Project,
+    Team,
+)
+from guildbotics.intelligences.brains.cli_agent import CliAgentBrain
+
+TICKET_STATUSES = ["Todo", "Doing", "Done"]
+CLI_AGENT_FAILURE_RETURNCODE = 2
+
+
+@dataclass
+class _CliResult:
+    returncode: int = 0
+    stdout: str = "OK"
+    stderr: str = ""
+
+
+class _StubBrain(CliAgentBrain):
+    """Minimal CliAgentBrain stand-in returning a canned execution result."""
+
+    def __init__(self, result: _CliResult) -> None:
+        self._result = result
+
+    async def run_with_execution_details(self, message: str, cwd: Any) -> _CliResult:
+        return self._result
+
+
+class _StubChatService:
+    def __init__(self, *, bot_user_id: str = "U123") -> None:
+        self.bot_user_id = bot_user_id
+
+    async def get_bot_identity(self) -> Any:
+        return type("Identity", (), {"user_id": self.bot_user_id})()
+
+    async def resolve_channel_id(self, channel_name: str) -> str:
+        return f"C-{channel_name}"
+
+    async def list_channel_events(self, channel_id: str, limit: int = 1) -> list:
+        return []
+
+
+class _StubTicketManager:
+    async def get_statuses(self) -> list[str]:
+        return list(TICKET_STATUSES)
+
+
+class _StubCodeHostingService:
+    async def get_default_branch(self) -> str:
+        return "main"
+
+
+@dataclass
+class _StubContext:
+    """Configurable Context stub shared across diagnostics test cases."""
+
+    team: Team
+    person: Person | None = None
+    brain: Any = None
+    ticket_manager: Any = field(default_factory=_StubTicketManager)
+    code_hosting_service: Any = field(default_factory=_StubCodeHostingService)
+    chat_service: Any = field(default_factory=_StubChatService)
+    talk_result: str = "OK"
+    logger: logging.Logger = field(
+        default_factory=lambda: logging.getLogger("diagnostics-test")
+    )
+
+    def clone_for(self, member: Person) -> _StubContext:
+        clone = _StubContext(
+            team=self.team,
+            person=member,
+            brain=self.brain,
+            ticket_manager=self.ticket_manager,
+            code_hosting_service=self.code_hosting_service,
+            chat_service=self.chat_service,
+            talk_result=self.talk_result,
+            logger=self.logger,
+        )
+        return clone
+
+    async def aclose(self) -> None:
+        return None
+
+    def get_brain(self, name: str, config: dict, _extra: Any) -> Any:
+        return self.brain
+
+    def get_ticket_manager(self) -> Any:
+        return self.ticket_manager
+
+    def get_code_hosting_service(self) -> Any:
+        return self.code_hosting_service
+
+    def get_chat_service(self) -> Any:
+        return self.chat_service
+
+
+def _person(person_id: str, **kwargs: Any) -> Person:
+    return Person(person_id=person_id, name=person_id.title(), **kwargs)
+
+
+def _team(members: list[Person], services: dict | None = None) -> Team:
+    return Team(project=Project(name="demo", services=services or {}), members=members)
+
+
+def _patch_cli(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    executable: str = "codex",
+    path: str = "/usr/local/bin/codex",
+) -> None:
+    monkeypatch.setattr(
+        diagnostics_module, "resolve_default_cli_executable", lambda: executable
+    )
+    monkeypatch.setattr(
+        diagnostics_module, "resolve_cli_agent_path", lambda *_a, **_k: path
+    )
+
+
+def _patch_talk(monkeypatch: pytest.MonkeyPatch, result: Any = "OK") -> None:
+    async def _talk(context: Any, *_args: Any, **_kwargs: Any) -> str:
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    monkeypatch.setattr(diagnostics_module, "talk_as", _talk)
+
+
+def _by_code(response: Any) -> dict:
+    return {check.code: check for check in response.checks}
+
+
+async def _run(
+    context: Any,
+    *,
+    context_error: Exception | None = None,
+    person_id: str | None = None,
+) -> Any:
+    return await ScenarioDiagnosticsService().run(
+        context=context, context_error=context_error, person_id=person_id
+    )
+
+
+@pytest.mark.asyncio
+async def test_context_construction_failure() -> None:
+    response = await _run(None, context_error=RuntimeError("cannot build context"))
+
+    checks = _by_code(response)
+    assert checks["config_load"].status == "error"
+    assert "cannot build context" in checks["config_load"].message
+    assert not response.ok
+    assert response.active_members == []
+
+
+@pytest.mark.asyncio
+async def test_context_missing_without_error() -> None:
+    response = await _run(None)
+
+    checks = _by_code(response)
+    assert checks["config_load"].status == "error"
+    assert checks["config_load"].message == "Configuration could not be loaded."
+
+
+@pytest.mark.asyncio
+async def test_person_id_not_found() -> None:
+    context = _StubContext(team=_team([_person("alice", is_active=True)]))
+
+    response = await _run(context, person_id="ghost")
+
+    checks = _by_code(response)
+    assert checks["member_not_found"].status == "error"
+    assert checks["member_not_found"].person_id == "ghost"
+    assert not response.ok
+
+
+@pytest.mark.asyncio
+async def test_no_active_members() -> None:
+    context = _StubContext(team=_team([_person("alice", is_active=False)]))
+
+    response = await _run(context)
+
+    checks = _by_code(response)
+    assert checks["active_members"].status == "error"
+    assert checks["active_members"].message == "No active members are configured."
+
+
+@pytest.mark.asyncio
+async def test_person_id_inactive_member_warns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_cli(monkeypatch)
+    _patch_talk(monkeypatch)
+    context = _StubContext(team=_team([_person("alice", is_active=False)]))
+
+    response = await _run(context, person_id="alice")
+
+    codes = {check.code for check in response.checks}
+    warning = next(c for c in response.warnings if c.code == "member_inactive")
+    assert warning.person_id == "alice"
+    assert warning.context["inactive_members"] == ["alice"]
+    assert "active_members" in codes
+
+
+@pytest.mark.asyncio
+async def test_multiple_active_members_listed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_cli(monkeypatch)
+    _patch_talk(monkeypatch)
+    context = _StubContext(
+        team=_team(
+            [
+                _person("alice", is_active=True),
+                _person("bob", is_active=True),
+                _person("carol", is_active=False),
+            ]
+        ),
+        brain=_StubBrain(_CliResult()),
+    )
+
+    response = await _run(context)
+
+    members_check = next(
+        c for c in response.checks if c.code == "active_members" and c.status == "ok"
+    )
+    assert members_check.context["members"] == ["alice", "bob"]
+    assert response.active_members == ["alice", "bob"]
+
+
+@pytest.mark.asyncio
+async def test_llm_live_call_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_cli(monkeypatch)
+    _patch_talk(monkeypatch, "OK")
+    context = _StubContext(
+        team=_team([_person("alice", is_active=True)]),
+        brain=_StubBrain(_CliResult()),
+    )
+
+    response = await _run(context)
+
+    check = _by_code(response)["llm_live_call"]
+    assert check.status == "ok"
+    assert check.person_id == "alice"
+
+
+@pytest.mark.asyncio
+async def test_llm_live_call_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_cli(monkeypatch)
+    _patch_talk(monkeypatch, RuntimeError("invalid api key"))
+    context = _StubContext(
+        team=_team([_person("alice", is_active=True)]),
+        brain=_StubBrain(_CliResult()),
+    )
+
+    response = await _run(context)
+
+    check = _by_code(response)["llm_live_call"]
+    assert check.status == "error"
+    assert "invalid api key" in check.message
+    assert check.context["error_type"] == "RuntimeError"
+    assert not response.ok
+
+
+@pytest.mark.asyncio
+async def test_cli_agent_mapping_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_talk(monkeypatch)
+    monkeypatch.setattr(
+        diagnostics_module, "resolve_default_cli_executable", lambda: ""
+    )
+    context = _StubContext(team=_team([_person("alice", is_active=True)]))
+
+    response = await _run(context)
+
+    check = _by_code(response)["cli_agent_mapping"]
+    assert check.status == "error"
+    assert check.message == "Default CLI agent executable could not be inferred."
+
+
+@pytest.mark.asyncio
+async def test_cli_agent_executable_not_found(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_talk(monkeypatch)
+    _patch_cli(monkeypatch, executable="codex", path="")
+    context = _StubContext(team=_team([_person("alice", is_active=True)]))
+
+    response = await _run(context)
+
+    check = _by_code(response)["cli_agent_executable"]
+    assert check.status == "error"
+    assert check.target == "codex"
+    assert "not found on PATH" in check.message
+
+
+@pytest.mark.asyncio
+async def test_cli_agent_executable_found_and_brain_ok(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_talk(monkeypatch)
+    _patch_cli(monkeypatch, path="/usr/local/bin/codex")
+    context = _StubContext(
+        team=_team([_person("alice", is_active=True)]),
+        brain=_StubBrain(_CliResult(returncode=0, stdout="OK")),
+    )
+
+    response = await _run(context)
+
+    checks = _by_code(response)
+    assert checks["cli_agent_executable"].status == "ok"
+    assert checks["cli_agent_executable"].context["path"] == "/usr/local/bin/codex"
+    assert checks["cli_agent_brain"].status == "ok"
+    assert checks["cli_agent_brain"].person_id == "alice"
+
+
+@pytest.mark.asyncio
+async def test_cli_agent_brain_non_zero_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_talk(monkeypatch)
+    _patch_cli(monkeypatch)
+    context = _StubContext(
+        team=_team([_person("alice", is_active=True)]),
+        brain=_StubBrain(
+            _CliResult(
+                returncode=CLI_AGENT_FAILURE_RETURNCODE,
+                stdout="",
+                stderr="login required",
+            )
+        ),
+    )
+
+    response = await _run(context)
+
+    check = _by_code(response)["cli_agent_brain"]
+    assert check.status == "error"
+    assert check.context["returncode"] == CLI_AGENT_FAILURE_RETURNCODE
+    assert "login required" in check.message
+
+
+@pytest.mark.asyncio
+async def test_cli_agent_brain_empty_stdout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_talk(monkeypatch)
+    _patch_cli(monkeypatch)
+    context = _StubContext(
+        team=_team([_person("alice", is_active=True)]),
+        brain=_StubBrain(_CliResult(returncode=0, stdout="   ", stderr="")),
+    )
+
+    response = await _run(context)
+
+    check = _by_code(response)["cli_agent_brain"]
+    assert check.status == "error"
+    assert check.context["empty_stdout"] is True
+
+
+@pytest.mark.asyncio
+async def test_cli_agent_brain_wrong_type(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_talk(monkeypatch)
+    _patch_cli(monkeypatch)
+    context = _StubContext(
+        team=_team([_person("alice", is_active=True)]),
+        brain=object(),
+    )
+
+    response = await _run(context)
+
+    check = _by_code(response)["cli_agent_brain"]
+    assert check.status == "error"
+    assert "not CliAgentBrain" in check.message
+
+
+@pytest.mark.asyncio
+async def test_github_not_configured_skipped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_talk(monkeypatch)
+    _patch_cli(monkeypatch)
+    context = _StubContext(
+        team=_team([_person("alice", is_active=True)]),
+        brain=_StubBrain(_CliResult()),
+    )
+
+    response = await _run(context)
+
+    check = _by_code(response)["github_not_configured"]
+    assert check.status == "ok"
+    assert "skipped" in check.message
+
+
+@pytest.mark.asyncio
+async def test_github_enabled_project_and_repository_access(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_talk(monkeypatch)
+    _patch_cli(monkeypatch)
+    services = {
+        "ticket_manager": {"name": "GitHub"},
+        "code_hosting_service": {"name": "GitHub"},
+    }
+    context = _StubContext(
+        team=_team([_person("alice", is_active=True)], services=services),
+        brain=_StubBrain(_CliResult()),
+    )
+
+    response = await _run(context)
+
+    checks = _by_code(response)
+    assert checks["github_project_access"].status == "ok"
+    assert checks["github_project_access"].context["status_count"] == len(
+        TICKET_STATUSES
+    )
+    # Repository / branch metadata is reported under the git section.
+    repo_check = checks["github_repository_access"]
+    assert repo_check.section == "git"
+    assert repo_check.status == "ok"
+    assert repo_check.context["default_branch"] == "main"
+
+
+@pytest.mark.asyncio
+async def test_github_access_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_talk(monkeypatch)
+    _patch_cli(monkeypatch)
+
+    class _FailingTicketManager:
+        async def get_statuses(self) -> list[str]:
+            raise RuntimeError("403 forbidden")
+
+    context = _StubContext(
+        team=_team(
+            [_person("alice", is_active=True)],
+            services={"ticket_manager": {"name": "GitHub"}},
+        ),
+        brain=_StubBrain(_CliResult()),
+        ticket_manager=_FailingTicketManager(),
+    )
+
+    response = await _run(context)
+
+    check = _by_code(response)["github_access"]
+    assert check.status == "error"
+    assert "403 forbidden" in check.message
+    assert not response.ok
+
+
+def _slack_member(person_id: str, *, enabled: bool = True) -> Person:
+    channel = MessageChannel(
+        name="general",
+        service="slack",
+        chat={"enabled": enabled, "channel_id": "C001", "channel_name": "general"},
+    )
+    return _person(person_id, is_active=True, message_channels=[channel])
+
+
+@pytest.mark.asyncio
+async def test_slack_not_configured_skipped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_talk(monkeypatch)
+    _patch_cli(monkeypatch)
+    context = _StubContext(
+        team=_team([_person("alice", is_active=True)]),
+        brain=_StubBrain(_CliResult()),
+    )
+
+    response = await _run(context)
+
+    check = _by_code(response)["slack_not_configured"]
+    assert check.status == "ok"
+
+
+@pytest.mark.asyncio
+async def test_slack_credential_present_and_channel_ok(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_talk(monkeypatch)
+    _patch_cli(monkeypatch)
+    monkeypatch.setenv("ALICE_SLACK_APP_TOKEN", "xapp-token")
+    context = _StubContext(
+        team=_team([_slack_member("alice")]),
+        brain=_StubBrain(_CliResult()),
+    )
+
+    response = await _run(context)
+
+    checks = _by_code(response)
+    assert "slack_app_token" not in checks
+    assert checks["slack_bot_auth"].status == "ok"
+    assert checks["slack_bot_auth"].context["bot_user_id"] == "U123"
+    assert checks["slack_channel_history"].status == "ok"
+
+
+@pytest.mark.asyncio
+async def test_slack_credential_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_talk(monkeypatch)
+    _patch_cli(monkeypatch)
+    monkeypatch.delenv("ALICE_SLACK_APP_TOKEN", raising=False)
+    context = _StubContext(
+        team=_team([_slack_member("alice")]),
+        brain=_StubBrain(_CliResult()),
+    )
+
+    response = await _run(context)
+
+    check = _by_code(response)["slack_app_token"]
+    assert check.status == "error"
+    assert check.target == "ALICE_SLACK_APP_TOKEN"
+    assert not response.ok
+
+
+@pytest.mark.asyncio
+async def test_slack_access_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_talk(monkeypatch)
+    _patch_cli(monkeypatch)
+    monkeypatch.setenv("ALICE_SLACK_APP_TOKEN", "xapp-token")
+
+    class _FailingChat(_StubChatService):
+        async def get_bot_identity(self) -> Any:
+            raise RuntimeError("invalid_auth")
+
+    context = _StubContext(
+        team=_team([_slack_member("alice")]),
+        brain=_StubBrain(_CliResult()),
+        chat_service=_FailingChat(),
+    )
+
+    response = await _run(context)
+
+    check = _by_code(response)["slack_access"]
+    assert check.status == "error"
+    assert "invalid_auth" in check.message
+
+
+@pytest.mark.asyncio
+async def test_person_id_targets_single_member(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_talk(monkeypatch)
+    _patch_cli(monkeypatch)
+    context = _StubContext(
+        team=_team(
+            [
+                _person("alice", is_active=True),
+                _person("bob", is_active=True),
+            ]
+        ),
+        brain=_StubBrain(_CliResult()),
+    )
+
+    response = await _run(context, person_id="bob")
+
+    assert response.active_members == ["bob"]
+    llm_checks = [c for c in response.checks if c.code == "llm_live_call"]
+    assert [c.person_id for c in llm_checks] == ["bob"]

--- a/tests/guildbotics/app_api/test_diagnostics.py
+++ b/tests/guildbotics/app_api/test_diagnostics.py
@@ -136,6 +136,18 @@ def _patch_talk(monkeypatch: pytest.MonkeyPatch, result: Any = "OK") -> None:
     monkeypatch.setattr(diagnostics_module, "talk_as", _talk)
 
 
+def _patch_provider(monkeypatch: pytest.MonkeyPatch, provider: str = "openai") -> None:
+    """Pin the resolved LLM provider so the missing-key gate is exercised.
+
+    The provider resolver normally reads ``intelligences/model_mapping.yml``
+    from the configured workspace; tests run in a tmp tree where that file is
+    not seeded, so we set the value explicitly to make behavior deterministic.
+    """
+    monkeypatch.setattr(
+        diagnostics_module, "resolve_default_model_provider", lambda: provider
+    )
+
+
 def _by_code(response: Any) -> dict:
     return {check.code: check for check in response.checks}
 
@@ -240,6 +252,8 @@ async def test_multiple_active_members_listed(
 @pytest.mark.asyncio
 async def test_llm_live_call_ok(monkeypatch: pytest.MonkeyPatch) -> None:
     _patch_cli(monkeypatch)
+    _patch_provider(monkeypatch, "openai")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
     _patch_talk(monkeypatch, "OK")
     context = _StubContext(
         team=_team([_person("alice", is_active=True)]),
@@ -256,6 +270,8 @@ async def test_llm_live_call_ok(monkeypatch: pytest.MonkeyPatch) -> None:
 @pytest.mark.asyncio
 async def test_llm_live_call_error(monkeypatch: pytest.MonkeyPatch) -> None:
     _patch_cli(monkeypatch)
+    _patch_provider(monkeypatch, "openai")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
     _patch_talk(monkeypatch, RuntimeError("invalid api key"))
     context = _StubContext(
         team=_team([_person("alice", is_active=True)]),
@@ -269,6 +285,68 @@ async def test_llm_live_call_error(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "invalid api key" in check.message
     assert check.context["error_type"] == "RuntimeError"
     assert not response.ok
+
+
+@pytest.mark.asyncio
+async def test_llm_check_skipped_when_api_key_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing provider key short-circuits the LLM check WITHOUT firing talk_as.
+
+    This keeps the scenario diagnostics offline-deterministic so the desktop
+    E2E does not depend on a live OpenAI round-trip (and so CI runners and
+    offline dev environments do not produce false negatives).
+    """
+    _patch_cli(monkeypatch)
+    _patch_provider(monkeypatch, "openai")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    talk_calls: list[Any] = []
+
+    async def _talk(*args: Any, **kwargs: Any) -> str:  # pragma: no cover
+        talk_calls.append((args, kwargs))
+        return "OK"
+
+    monkeypatch.setattr(diagnostics_module, "talk_as", _talk)
+    context = _StubContext(
+        team=_team([_person("alice", is_active=True)]),
+        brain=_StubBrain(_CliResult()),
+    )
+
+    response = await _run(context)
+    checks = _by_code(response)
+
+    assert "llm_live_call" not in checks
+    fast_error = checks["llm_api_key"]
+    assert fast_error.status == "error"
+    assert "OPENAI_API_KEY is not configured" in fast_error.message
+    assert fast_error.context["provider"] == "openai"
+    assert fast_error.context["env_key"] == "OPENAI_API_KEY"
+    assert fast_error.person_id == "alice"
+    assert talk_calls == []
+
+
+@pytest.mark.asyncio
+async def test_llm_check_falls_through_when_provider_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unmappable provider does not short-circuit; the live path still runs.
+
+    Preserves backwards-compatible behavior for configurations whose default
+    model name does not match a known provider.
+    """
+    _patch_cli(monkeypatch)
+    _patch_provider(monkeypatch, "")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    _patch_talk(monkeypatch, "OK")
+    context = _StubContext(
+        team=_team([_person("alice", is_active=True)]),
+        brain=_StubBrain(_CliResult()),
+    )
+
+    response = await _run(context)
+
+    check = _by_code(response)["llm_live_call"]
+    assert check.status == "ok"
 
 
 @pytest.mark.asyncio
@@ -550,6 +628,8 @@ async def test_person_id_targets_single_member(
 ) -> None:
     _patch_talk(monkeypatch)
     _patch_cli(monkeypatch)
+    _patch_provider(monkeypatch, "openai")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
     context = _StubContext(
         team=_team(
             [

--- a/tests/guildbotics/app_api/test_events.py
+++ b/tests/guildbotics/app_api/test_events.py
@@ -1,0 +1,201 @@
+"""Unit tests for ``guildbotics.app_api.events``."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+
+import pytest
+
+from guildbotics.app_api.events import (
+    CommandEventLogHandler,
+    EventBus,
+    EventBusLogHandler,
+)
+
+EXPECTED_HISTORY_LEN = 3
+
+
+async def _get_with_timeout(subscription, timeout: float = 2.0) -> dict[str, object]:
+    return await asyncio.wait_for(subscription.get(), timeout=timeout)
+
+
+@pytest.mark.asyncio
+async def test_event_bus_respects_history_limit() -> None:
+    bus = EventBus(history_limit=3)
+    for index in range(5):
+        bus.publish_event("tick", {"index": index})
+
+    snapshot = bus.snapshot_events()
+    assert len(snapshot) == EXPECTED_HISTORY_LEN
+    assert [item["payload"]["index"] for item in snapshot] == [2, 3, 4]
+
+
+@pytest.mark.asyncio
+async def test_subscribe_replays_existing_history() -> None:
+    bus = EventBus()
+    bus.publish_event("first", {"n": 1})
+    bus.publish_event("second", {"n": 2})
+
+    subscription = bus.subscribe_events()
+    try:
+        first = await _get_with_timeout(subscription)
+        second = await _get_with_timeout(subscription)
+    finally:
+        subscription.close()
+
+    assert first["type"] == "first"
+    assert first["payload"] == {"n": 1}
+    assert second["type"] == "second"
+    assert second["payload"] == {"n": 2}
+
+
+@pytest.mark.asyncio
+async def test_no_publish_to_subscriber_after_close() -> None:
+    bus = EventBus()
+    subscription = bus.subscribe_events()
+    subscription.close()
+
+    bus.publish_event("after-close", {"n": 1})
+
+    with pytest.raises(asyncio.TimeoutError):
+        await _get_with_timeout(subscription, timeout=0.2)
+
+
+@pytest.mark.asyncio
+async def test_event_and_log_history_are_separate() -> None:
+    bus = EventBus()
+    bus.publish_event("command.started", {"command": "hello"})
+    bus.publish_log("INFO", "log line")
+
+    event_sub = bus.subscribe_events()
+    log_sub = bus.subscribe_logs()
+    try:
+        event_item = await _get_with_timeout(event_sub)
+        log_item = await _get_with_timeout(log_sub)
+
+        # Event subscriber must not see the log entry and vice versa.
+        with pytest.raises(asyncio.TimeoutError):
+            await _get_with_timeout(event_sub, timeout=0.2)
+        with pytest.raises(asyncio.TimeoutError):
+            await _get_with_timeout(log_sub, timeout=0.2)
+    finally:
+        event_sub.close()
+        log_sub.close()
+
+    assert event_item["type"] == "command.started"
+    assert "level" not in event_item
+    assert log_item["level"] == "INFO"
+    assert log_item["message"] == "log line"
+    assert "type" not in log_item
+
+
+@pytest.mark.asyncio
+async def test_live_event_payload_shape() -> None:
+    bus = EventBus()
+    subscription = bus.subscribe_events()
+    try:
+        bus.publish_event("command.done", {"ok": True}, request_id="req-1")
+        item = await _get_with_timeout(subscription)
+    finally:
+        subscription.close()
+
+    assert item["type"] == "command.done"
+    assert item["request_id"] == "req-1"
+    assert item["payload"] == {"ok": True}
+    assert item["timestamp"]
+
+
+@pytest.mark.asyncio
+async def test_publish_event_defaults_payload_to_empty_dict() -> None:
+    bus = EventBus()
+    subscription = bus.subscribe_events()
+    try:
+        bus.publish_event("bare")
+        item = await _get_with_timeout(subscription)
+    finally:
+        subscription.close()
+
+    assert item["payload"] == {}
+    assert item["request_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_background_thread_publish_reaches_async_subscriber() -> None:
+    bus = EventBus()
+    subscription = bus.subscribe_events()
+
+    def publish_from_thread() -> None:
+        bus.publish_event("from-thread", {"n": 42})
+
+    thread = threading.Thread(target=publish_from_thread)
+    try:
+        thread.start()
+        item = await _get_with_timeout(subscription)
+    finally:
+        thread.join(timeout=2.0)
+        subscription.close()
+
+    assert item["type"] == "from-thread"
+    assert item["payload"] == {"n": 42}
+
+
+@pytest.mark.asyncio
+async def test_event_bus_log_handler_publishes_formatted_log() -> None:
+    bus = EventBus()
+    log_sub = bus.subscribe_logs()
+    event_sub = bus.subscribe_events()
+
+    logger = logging.getLogger("test_event_bus_log_handler")
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+    handler = EventBusLogHandler(bus)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    logger.addHandler(handler)
+
+    try:
+        logger.warning("disk almost full")
+        item = await _get_with_timeout(log_sub)
+
+        # A plain log handler must not emit on the event channel.
+        with pytest.raises(asyncio.TimeoutError):
+            await _get_with_timeout(event_sub, timeout=0.2)
+    finally:
+        logger.removeHandler(handler)
+        log_sub.close()
+        event_sub.close()
+
+    assert item["level"] == "WARNING"
+    assert item["message"] == "disk almost full"
+    assert item["request_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_command_event_log_handler_publishes_command_log_event() -> None:
+    bus = EventBus()
+    event_sub = bus.subscribe_events()
+    log_sub = bus.subscribe_logs()
+
+    logger = logging.getLogger("test_command_event_log_handler")
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+    handler = CommandEventLogHandler(bus, request_id="req-42")
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    logger.addHandler(handler)
+
+    try:
+        logger.error("command failed")
+        item = await _get_with_timeout(event_sub)
+
+        # The command log handler emits on the event channel, not the log one.
+        with pytest.raises(asyncio.TimeoutError):
+            await _get_with_timeout(log_sub, timeout=0.2)
+    finally:
+        logger.removeHandler(handler)
+        event_sub.close()
+        log_sub.close()
+
+    assert item["type"] == "command.log"
+    assert item["request_id"] == "req-42"
+    assert item["payload"] == {"level": "ERROR", "message": "command failed"}

--- a/tests/guildbotics/app_api/test_intelligences.py
+++ b/tests/guildbotics/app_api/test_intelligences.py
@@ -1,0 +1,472 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from guildbotics.app_api import intelligences as intelligences_module
+from guildbotics.app_api.intelligences import (
+    AGNO_BRAIN_CLASS,
+    CLI_BRAIN_CLASS,
+    IntelligenceConfigService,
+)
+from guildbotics.app_api.models import (
+    BrainAssignment,
+    CliAgentDefinition,
+    IntelligenceConfigUpdateRequest,
+    ModelDefinition,
+)
+from guildbotics.editions.simple import simple_brain_factory
+from guildbotics.intelligences.brains import agno_agent, cli_agent
+from guildbotics.utils.fileio import load_yaml_file, save_yaml_file
+
+
+def _write_yaml(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    save_yaml_file(path, data)
+
+
+def _team_intelligences(config_dir: Path) -> Path:
+    return config_dir / "intelligences"
+
+
+def _member_intelligences(config_dir: Path, person_id: str) -> Path:
+    return config_dir / "team/members" / person_id / "intelligences"
+
+
+def _write_team_config(config_dir: Path) -> None:
+    """Write a minimal but complete team-scoped intelligences config."""
+    base = _team_intelligences(config_dir)
+    _write_yaml(
+        base / "model_mapping.yml",
+        {
+            "default": "models/openai/gpt.yml",
+            "openai": "models/openai/gpt.yml",
+        },
+    )
+    _write_yaml(
+        base / "models/openai/gpt.yml",
+        {"model_class": "team.ModelClass", "parameters": {"id": "team-model-id"}},
+    )
+    _write_yaml(
+        base / "cli_agent_mapping.yml",
+        {"default": "codex-cli.yml"},
+    )
+    _write_yaml(
+        base / "cli_agents/codex-cli.yml",
+        {"env": {"FOO": "bar"}, "script": "codex exec"},
+    )
+    _write_yaml(
+        base / "brain_mapping.yml",
+        {
+            "default": {
+                "class": AGNO_BRAIN_CLASS,
+                "args": {"model": "default"},
+            },
+            "file_editor": {
+                "class": CLI_BRAIN_CLASS,
+                "args": {"cli_agent": "default"},
+            },
+        },
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches() -> None:
+    simple_brain_factory.person_brain_mapping.clear()
+    agno_agent.person_model_mapping.clear()
+    cli_agent.person_cli_agent_mapping.clear()
+
+
+# --------------------------------------------------------------------------- #
+# read_config
+# --------------------------------------------------------------------------- #
+
+
+def test_read_config_template_fallback_when_team_config_absent(tmp_path: Path) -> None:
+    """No team config on disk -> falls back to the packaged template mappings."""
+    response = IntelligenceConfigService().read_config(config_dir=tmp_path)
+
+    assert response.person_id is None
+    assert response.inherited is False
+    # Template ships a "default" model mapping entry.
+    assert "default" in response.model_mapping
+    assert response.models, "template models should be read via fallback"
+    assert all(model.path.startswith("models/") for model in response.models)
+    assert response.brain_mapping, "template brain mapping should be parsed"
+
+
+def test_read_config_member_without_override_is_inherited(tmp_path: Path) -> None:
+    _write_team_config(tmp_path)
+
+    response = IntelligenceConfigService().read_config(
+        config_dir=tmp_path, person_id="alice"
+    )
+
+    assert response.person_id == "alice"
+    assert response.inherited is True
+    # Inherited values come from the team scope.
+    assert response.model_mapping["default"] == "models/openai/gpt.yml"
+    assert response.models[0].model_id == "team-model-id"
+
+
+def test_read_config_member_with_override_not_inherited(tmp_path: Path) -> None:
+    _write_team_config(tmp_path)
+    member_base = _member_intelligences(tmp_path, "alice")
+    _write_yaml(
+        member_base / "model_mapping.yml",
+        {"default": "models/anthropic/claude.yml"},
+    )
+    _write_yaml(
+        member_base / "models/anthropic/claude.yml",
+        {"model_class": "member.ModelClass", "parameters": {"id": "member-model-id"}},
+    )
+
+    response = IntelligenceConfigService().read_config(
+        config_dir=tmp_path, person_id="alice"
+    )
+
+    assert response.inherited is False
+    assert response.model_mapping["default"] == "models/anthropic/claude.yml"
+    assert response.models[0].provider == "anthropic"
+    assert response.models[0].model_id == "member-model-id"
+
+
+def test_read_config_deduplicates_model_file_reads(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A model path referenced by several mapping keys is read only once."""
+    base = _team_intelligences(tmp_path)
+    _write_yaml(
+        base / "model_mapping.yml",
+        {
+            "default": "models/openai/gpt.yml",
+            "openai": "models/openai/gpt.yml",
+            "fast": "models/openai/gpt.yml",
+        },
+    )
+    _write_yaml(
+        base / "models/openai/gpt.yml",
+        {"model_class": "team.ModelClass", "parameters": {"id": "team-model-id"}},
+    )
+    _write_yaml(base / "cli_agent_mapping.yml", {})
+    _write_yaml(base / "brain_mapping.yml", {})
+
+    model_file = (base / "models/openai/gpt.yml").resolve()
+    read_counts: dict[Path, int] = {}
+    real_load = load_yaml_file
+
+    def counting_load(file: Path):
+        resolved = Path(file).resolve()
+        read_counts[resolved] = read_counts.get(resolved, 0) + 1
+        return real_load(file)
+
+    monkeypatch.setattr(intelligences_module, "load_yaml_file", counting_load)
+
+    response = IntelligenceConfigService().read_config(config_dir=tmp_path)
+
+    assert len(response.models) == 1
+    assert read_counts.get(model_file) == 1
+
+
+def test_read_config_handles_malformed_yaml(tmp_path: Path) -> None:
+    """Malformed model file -> empty model fields, no crash."""
+    base = _team_intelligences(tmp_path)
+    _write_yaml(base / "model_mapping.yml", {"default": "models/openai/gpt.yml"})
+    (base / "models/openai").mkdir(parents=True, exist_ok=True)
+    # A YAML scalar (string), not a mapping -> treated as empty dict.
+    (base / "models/openai/gpt.yml").write_text("just-a-string\n", encoding="utf-8")
+    _write_yaml(base / "cli_agent_mapping.yml", {})
+    _write_yaml(base / "brain_mapping.yml", {})
+
+    response = IntelligenceConfigService().read_config(config_dir=tmp_path)
+
+    assert len(response.models) == 1
+    model = response.models[0]
+    assert model.path == "models/openai/gpt.yml"
+    assert model.model_class == ""
+    assert model.model_id == ""
+
+
+def test_read_config_cli_agent_env_not_dict_falls_back(tmp_path: Path) -> None:
+    base = _team_intelligences(tmp_path)
+    _write_yaml(base / "model_mapping.yml", {})
+    _write_yaml(base / "cli_agent_mapping.yml", {"default": "codex-cli.yml"})
+    # env is a list rather than a dict.
+    (base / "cli_agents").mkdir(parents=True, exist_ok=True)
+    (base / "cli_agents/codex-cli.yml").write_text(
+        "env:\n  - not-a-dict\nscript: run\n", encoding="utf-8"
+    )
+    _write_yaml(base / "brain_mapping.yml", {})
+
+    response = IntelligenceConfigService().read_config(config_dir=tmp_path)
+
+    assert len(response.cli_agents) == 1
+    agent = response.cli_agents[0]
+    assert agent.env == {}
+    assert agent.script == "run"
+    assert agent.name == "codex-cli"
+
+
+def test_read_config_cli_agent_detected_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    base = _team_intelligences(tmp_path)
+    _write_yaml(base / "model_mapping.yml", {})
+    _write_yaml(base / "cli_agent_mapping.yml", {"default": "codex-cli.yml"})
+    _write_yaml(base / "cli_agents/codex-cli.yml", {"env": {}, "script": "codex run"})
+    _write_yaml(base / "brain_mapping.yml", {})
+
+    def fake_resolve_cli_agent_path(executable: str) -> str:
+        # The service strips the "-cli" suffix before resolving.
+        return "/usr/local/bin/codex" if executable == "codex" else ""
+
+    monkeypatch.setattr(
+        intelligences_module, "resolve_cli_agent_path", fake_resolve_cli_agent_path
+    )
+
+    response = IntelligenceConfigService().read_config(config_dir=tmp_path)
+
+    agent = response.cli_agents[0]
+    assert agent.detected is True
+    assert agent.detected_path == "/usr/local/bin/codex"
+
+
+def test_read_config_brain_mapping_engine_classification(tmp_path: Path) -> None:
+    base = _team_intelligences(tmp_path)
+    _write_yaml(base / "model_mapping.yml", {})
+    _write_yaml(base / "cli_agent_mapping.yml", {})
+    _write_yaml(
+        base / "brain_mapping.yml",
+        {
+            "llm_brain": {"class": AGNO_BRAIN_CLASS, "args": {"model": "openai"}},
+            "cli_brain": {"class": CLI_BRAIN_CLASS, "args": {"cli_agent": "codex"}},
+            "skipped": "not-a-dict",
+        },
+    )
+
+    response = IntelligenceConfigService().read_config(config_dir=tmp_path)
+
+    by_name = {b.name: b for b in response.brain_mapping}
+    assert set(by_name) == {"llm_brain", "cli_brain"}
+    assert by_name["llm_brain"].engine == "llm"
+    assert by_name["llm_brain"].target == "openai"
+    assert by_name["cli_brain"].engine == "cli"
+    assert by_name["cli_brain"].target == "codex"
+
+
+# --------------------------------------------------------------------------- #
+# update_config (team scope)
+# --------------------------------------------------------------------------- #
+
+
+def _team_update_request(config_dir: Path) -> IntelligenceConfigUpdateRequest:
+    return IntelligenceConfigUpdateRequest(
+        config_dir=config_dir,
+        person_id=None,
+        model_mapping={"default": "models/openai/gpt.yml"},
+        models=[
+            ModelDefinition(
+                path="models/openai/gpt.yml",
+                provider="openai",
+                model_class="openai.Class",
+                model_id="gpt-test",
+            )
+        ],
+        cli_agent_mapping={"default": "codex-cli.yml"},
+        cli_agents=[
+            CliAgentDefinition(
+                path="codex-cli.yml",
+                name="codex-cli",
+                env={"KEY": "value"},
+                script="codex exec",
+            )
+        ],
+        brain_mapping=[
+            BrainAssignment(
+                name="default",
+                brain_class=AGNO_BRAIN_CLASS,
+                engine="llm",
+                target="default",
+            ),
+            BrainAssignment(
+                name="file_editor",
+                brain_class=CLI_BRAIN_CLASS,
+                engine="cli",
+                target="codex",
+            ),
+        ],
+    )
+
+
+def test_team_update_writes_all_files(tmp_path: Path) -> None:
+    request = _team_update_request(tmp_path)
+
+    result = IntelligenceConfigService().update_config(request)
+
+    base = _team_intelligences(tmp_path)
+    model_file = base / "models/openai/gpt.yml"
+    cli_file = base / "cli_agents/codex-cli.yml"
+
+    written = {f.path for f in result.files}
+    assert (base / "model_mapping.yml") in written
+    assert model_file in written
+    assert (base / "cli_agent_mapping.yml") in written
+    assert cli_file in written
+    assert (base / "brain_mapping.yml") in written
+    assert all(f.action == "update" for f in result.files)
+
+    # Files exist on disk with expected content.
+    assert load_yaml_file(base / "model_mapping.yml") == {
+        "default": "models/openai/gpt.yml"
+    }
+    model_data = load_yaml_file(model_file)
+    assert model_data["model_class"] == "openai.Class"
+    assert model_data["parameters"]["id"] == "gpt-test"
+    assert load_yaml_file(cli_file) == {"env": {"KEY": "value"}, "script": "codex exec"}
+
+    brain_data = load_yaml_file(base / "brain_mapping.yml")
+    assert brain_data["default"] == {
+        "class": AGNO_BRAIN_CLASS,
+        "args": {"model": "default"},
+    }
+    assert brain_data["file_editor"] == {
+        "class": CLI_BRAIN_CLASS,
+        "args": {"cli_agent": "codex"},
+    }
+
+
+def test_team_update_merges_existing_model_file(tmp_path: Path) -> None:
+    """Existing model file extra parameters are preserved on update."""
+    base = _team_intelligences(tmp_path)
+    temperature = 0.5
+    _write_yaml(
+        base / "models/openai/gpt.yml",
+        {
+            "model_class": "old.Class",
+            "parameters": {"id": "old-id", "temperature": temperature},
+        },
+    )
+
+    request = _team_update_request(tmp_path)
+    IntelligenceConfigService().update_config(request)
+
+    model_data = load_yaml_file(base / "models/openai/gpt.yml")
+    assert model_data["model_class"] == "openai.Class"
+    assert model_data["parameters"]["id"] == "gpt-test"
+    assert model_data["parameters"]["temperature"] == temperature
+
+
+def test_team_update_clears_all_runtime_caches(tmp_path: Path) -> None:
+    simple_brain_factory.person_brain_mapping["alice"] = {}
+    agno_agent.person_model_mapping["alice"] = {}
+    cli_agent.person_cli_agent_mapping["bob"] = {}
+
+    IntelligenceConfigService().update_config(_team_update_request(tmp_path))
+
+    assert simple_brain_factory.person_brain_mapping == {}
+    assert agno_agent.person_model_mapping == {}
+    assert cli_agent.person_cli_agent_mapping == {}
+
+
+# --------------------------------------------------------------------------- #
+# update_config (member scope)
+# --------------------------------------------------------------------------- #
+
+
+def test_member_override_update_writes_only_member_mapping_files(
+    tmp_path: Path,
+) -> None:
+    request = IntelligenceConfigUpdateRequest(
+        config_dir=tmp_path,
+        person_id="alice",
+        model_mapping={"default": "models/openai/gpt.yml"},
+        cli_agent_mapping={"default": "codex-cli.yml"},
+    )
+
+    result = IntelligenceConfigService().update_config(request)
+
+    base = _member_intelligences(tmp_path, "alice")
+    written = {f.path for f in result.files}
+    assert written == {
+        base / "model_mapping.yml",
+        base / "cli_agent_mapping.yml",
+    }
+    # Member override does NOT write model files, cli_agents, or brain mapping.
+    assert not (base / "brain_mapping.yml").exists()
+    assert not (base / "cli_agents").exists()
+    assert not (base / "models").exists()
+    assert load_yaml_file(base / "model_mapping.yml") == {
+        "default": "models/openai/gpt.yml"
+    }
+
+
+def test_member_override_update_replaces_existing_dir(tmp_path: Path) -> None:
+    base = _member_intelligences(tmp_path, "alice")
+    stale = base / "stale.yml"
+    _write_yaml(stale, {"old": "data"})
+
+    request = IntelligenceConfigUpdateRequest(
+        config_dir=tmp_path,
+        person_id="alice",
+        model_mapping={"default": "models/openai/gpt.yml"},
+        cli_agent_mapping={},
+    )
+    IntelligenceConfigService().update_config(request)
+
+    assert not stale.exists()
+    assert (base / "model_mapping.yml").exists()
+
+
+def test_member_override_update_clears_only_member_cache(tmp_path: Path) -> None:
+    simple_brain_factory.person_brain_mapping["alice"] = {}
+    simple_brain_factory.person_brain_mapping["bob"] = {}
+    agno_agent.person_model_mapping["alice"] = {}
+    cli_agent.person_cli_agent_mapping["alice"] = {}
+
+    request = IntelligenceConfigUpdateRequest(
+        config_dir=tmp_path,
+        person_id="alice",
+        model_mapping={},
+        cli_agent_mapping={},
+    )
+    IntelligenceConfigService().update_config(request)
+
+    assert "alice" not in simple_brain_factory.person_brain_mapping
+    assert "bob" in simple_brain_factory.person_brain_mapping
+    assert "alice" not in agno_agent.person_model_mapping
+    assert "alice" not in cli_agent.person_cli_agent_mapping
+
+
+def test_inherit_team_defaults_deletes_member_intelligences(tmp_path: Path) -> None:
+    base = _member_intelligences(tmp_path, "alice")
+    _write_yaml(base / "model_mapping.yml", {"default": "models/openai/gpt.yml"})
+    simple_brain_factory.person_brain_mapping["alice"] = {}
+
+    request = IntelligenceConfigUpdateRequest(
+        config_dir=tmp_path,
+        person_id="alice",
+        inherit_team_defaults=True,
+    )
+    result = IntelligenceConfigService().update_config(request)
+
+    assert not base.exists()
+    assert len(result.files) == 1
+    assert result.files[0].path == base
+    assert result.files[0].action == "delete"
+    assert "alice" not in simple_brain_factory.person_brain_mapping
+
+
+def test_inherit_team_defaults_when_no_member_dir(tmp_path: Path) -> None:
+    """Inherit with no existing member dir is a no-op delete that still reports."""
+    request = IntelligenceConfigUpdateRequest(
+        config_dir=tmp_path,
+        person_id="alice",
+        inherit_team_defaults=True,
+    )
+    result = IntelligenceConfigService().update_config(request)
+
+    base = _member_intelligences(tmp_path, "alice")
+    assert not base.exists()
+    assert len(result.files) == 1
+    assert result.files[0].action == "delete"

--- a/tests/guildbotics/app_api/test_lifecycle.py
+++ b/tests/guildbotics/app_api/test_lifecycle.py
@@ -1,0 +1,565 @@
+"""Unit tests for ``guildbotics.app_api.lifecycle``.
+
+The real scheduler / event-listener runners and the context factory are replaced
+with light-weight fakes so that no real scheduler loop or external I/O runs. The
+tests assert concrete observable behaviour: published event sequences, status
+fields (``state`` / ``running`` / metadata), thread non-duplication and stop
+ordering.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import threading
+import time
+from typing import Any, ClassVar
+
+import pytest
+
+from guildbotics.app_api import lifecycle
+from guildbotics.app_api.events import EventBus
+from guildbotics.app_api.models import SchedulerStartRequest
+
+DEFAULT_ROUTINES = ["workflows/ticket_driven_workflow"]
+EXPECTED_WORKER_COUNT = 2
+EXPECTED_MEMBER_COUNT = 2
+EXPECTED_MAX_ERRORS = 5
+EXPECTED_INTERVAL = 7
+REFRESHED_WORKER_COUNT = 3
+
+
+def _wait_until(predicate: Any, timeout: float = 2.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return predicate()
+
+
+def _event_types(bus: EventBus) -> list[str]:
+    return [item["type"] for item in bus.snapshot_events()]
+
+
+def _events_for(bus: EventBus, target: str) -> list[str]:
+    return [t for t in _event_types(bus) if t.startswith(f"{target}.")]
+
+
+class FakeScheduler:
+    """Stand-in for ``TaskScheduler`` driven entirely by test signals."""
+
+    instances: ClassVar[list[FakeScheduler]] = []
+
+    def __init__(
+        self,
+        context: Any,
+        routine_commands: list[str],
+        *,
+        consecutive_error_limit: int,
+        routine_interval_minutes: int,
+    ) -> None:
+        self.context = context
+        self.routine_commands = routine_commands
+        self.consecutive_error_limit = consecutive_error_limit
+        self.routine_interval_minutes = routine_interval_minutes
+        self._stop = threading.Event()
+        self.shutdown_calls: list[dict[str, Any]] = []
+        self.start_error: Exception | None = None
+        self.summary: dict[str, Any] = {
+            "active_member_count": 2,
+            "worker_count": 2,
+            "routine_interval_minutes": routine_interval_minutes,
+        }
+        self.block_shutdown = False
+        FakeScheduler.instances.append(self)
+
+    def start(self) -> None:
+        if self.start_error is not None:
+            raise self.start_error
+        # Block until shutdown is requested, mimicking a running loop.
+        self._stop.wait()
+
+    def shutdown(self, graceful: bool = True, timeout: float | None = None) -> None:
+        self.shutdown_calls.append({"graceful": graceful, "timeout": timeout})
+        if not self.block_shutdown:
+            self._stop.set()
+
+    def get_status_summary(self) -> dict[str, Any]:
+        return dict(self.summary)
+
+
+class FakeRunner:
+    """Stand-in for ``EventListenerRunner``."""
+
+    instances: ClassVar[list[FakeRunner]] = []
+
+    def __init__(self, context: Any) -> None:
+        self.context = context
+        self._alive = True
+        self.start_calls = 0
+        self.stop_calls = 0
+        self.join_calls: list[float | None] = []
+        self.block_stop = False
+        self.summary: dict[str, Any] = {
+            "workflow_command": "workflows/event_driven_workflow",
+            "subscription_count": 1,
+            "listener_count": 1,
+            "cycle_count": 0,
+            "cycle_failure_count": 0,
+            "events_drained_count": 0,
+            "events_delivered_count": 0,
+            "events_skipped_processed_count": 0,
+        }
+        FakeRunner.instances.append(self)
+
+    def start(self) -> None:
+        self.start_calls += 1
+
+    def stop(self) -> None:
+        self.stop_calls += 1
+        if not self.block_stop:
+            self._alive = False
+
+    def join(self, timeout: float | None = None) -> None:
+        self.join_calls.append(timeout)
+
+    def is_alive(self) -> bool:
+        return self._alive
+
+    def get_status_summary(self) -> dict[str, Any]:
+        return dict(self.summary)
+
+
+@pytest.fixture
+def context_factory() -> Any:
+    sentinel = object()
+
+    def factory() -> Any:
+        return sentinel
+
+    factory.sentinel = sentinel  # type: ignore[attr-defined]
+    return factory
+
+
+@pytest.fixture(autouse=True)
+def patch_runtimes(monkeypatch: pytest.MonkeyPatch) -> None:
+    FakeScheduler.instances = []
+    FakeRunner.instances = []
+    monkeypatch.setattr(lifecycle, "TaskScheduler", FakeScheduler)
+    monkeypatch.setattr(lifecycle, "EventListenerRunner", FakeRunner)
+
+
+def _make_service(
+    context_factory: Any,
+    *,
+    stop_timeout_seconds: float = 2.0,
+) -> tuple[lifecycle.RuntimeLifecycleService, EventBus]:
+    bus = EventBus()
+    service = lifecycle.RuntimeLifecycleService(
+        event_bus=bus,
+        context_factory=context_factory,
+        default_routines_factory=lambda: list(DEFAULT_ROUTINES),
+        stop_timeout_seconds=stop_timeout_seconds,
+    )
+    return service, bus
+
+
+def _stop_quietly(service: lifecycle.RuntimeLifecycleService) -> None:
+    with contextlib.suppress(Exception):
+        service.stop()
+
+
+# --------------------------------------------------------------------------- #
+# Start event sequencing
+# --------------------------------------------------------------------------- #
+
+
+def test_scheduler_start_publishes_starting_then_running(context_factory: Any) -> None:
+    service, bus = _make_service(context_factory)
+    try:
+        status = service.start(SchedulerStartRequest(only="scheduler"))
+
+        assert _events_for(bus, "scheduler") == [
+            "scheduler.starting",
+            "scheduler.running",
+        ]
+        assert _events_for(bus, "events") == []
+        assert status.scheduler.state == "running"
+        assert status.scheduler.running is True
+        assert status.events.state == "stopped"
+    finally:
+        _stop_quietly(service)
+
+
+def test_events_start_publishes_starting_then_running(context_factory: Any) -> None:
+    service, bus = _make_service(context_factory)
+    try:
+        status = service.start(SchedulerStartRequest(only="events"))
+
+        assert _events_for(bus, "events") == ["events.starting", "events.running"]
+        assert _events_for(bus, "scheduler") == []
+        assert status.events.state == "running"
+        assert status.events.running is True
+    finally:
+        _stop_quietly(service)
+
+
+def test_context_factory_is_used_for_runtimes(context_factory: Any) -> None:
+    service, _bus = _make_service(context_factory)
+    try:
+        service.start(SchedulerStartRequest())
+        assert FakeScheduler.instances[0].context is context_factory.sentinel
+        assert FakeRunner.instances[0].context is context_factory.sentinel
+    finally:
+        _stop_quietly(service)
+
+
+# --------------------------------------------------------------------------- #
+# Target selection
+# --------------------------------------------------------------------------- #
+
+
+def test_only_scheduler_starts_only_scheduler(context_factory: Any) -> None:
+    service, _bus = _make_service(context_factory)
+    try:
+        service.start(SchedulerStartRequest(only="scheduler"))
+        assert len(FakeScheduler.instances) == 1
+        assert FakeRunner.instances == []
+    finally:
+        _stop_quietly(service)
+
+
+def test_only_events_starts_only_events(context_factory: Any) -> None:
+    service, _bus = _make_service(context_factory)
+    try:
+        service.start(SchedulerStartRequest(only="events"))
+        assert FakeScheduler.instances == []
+        assert len(FakeRunner.instances) == 1
+    finally:
+        _stop_quietly(service)
+
+
+def test_both_targets_start_when_only_is_none(context_factory: Any) -> None:
+    service, bus = _make_service(context_factory)
+    try:
+        status = service.start(SchedulerStartRequest())
+        assert len(FakeScheduler.instances) == 1
+        assert len(FakeRunner.instances) == 1
+        assert status.scheduler.state == "running"
+        assert status.events.state == "running"
+        # Selection order starts events before scheduler.
+        assert _event_types(bus) == [
+            "events.starting",
+            "events.running",
+            "scheduler.starting",
+            "scheduler.running",
+        ]
+    finally:
+        _stop_quietly(service)
+
+
+# --------------------------------------------------------------------------- #
+# Non-duplication on re-start
+# --------------------------------------------------------------------------- #
+
+
+def test_restart_scheduler_does_not_spawn_duplicate(context_factory: Any) -> None:
+    service, bus = _make_service(context_factory)
+    try:
+        service.start(SchedulerStartRequest(only="scheduler"))
+        first_count = len(FakeScheduler.instances)
+
+        service.start(SchedulerStartRequest(only="scheduler"))
+
+        assert len(FakeScheduler.instances) == first_count == 1
+        # No additional starting/running events from the second call.
+        assert _events_for(bus, "scheduler") == [
+            "scheduler.starting",
+            "scheduler.running",
+        ]
+    finally:
+        _stop_quietly(service)
+
+
+def test_restart_events_does_not_spawn_duplicate(context_factory: Any) -> None:
+    service, bus = _make_service(context_factory)
+    try:
+        service.start(SchedulerStartRequest(only="events"))
+        service.start(SchedulerStartRequest(only="events"))
+
+        assert len(FakeRunner.instances) == 1
+        assert _events_for(bus, "events") == ["events.starting", "events.running"]
+    finally:
+        _stop_quietly(service)
+
+
+# --------------------------------------------------------------------------- #
+# Metadata
+# --------------------------------------------------------------------------- #
+
+
+def test_scheduler_metadata_reflects_request_and_summary(context_factory: Any) -> None:
+    service, _bus = _make_service(context_factory)
+    try:
+        service.start(
+            SchedulerStartRequest(
+                only="scheduler",
+                routine_commands=["custom/routine"],
+                max_consecutive_errors=5,
+                routine_interval_minutes=7,
+            )
+        )
+        status = service.get_status().scheduler
+        assert status.routine_commands == ["custom/routine"]
+        assert status.max_consecutive_errors == EXPECTED_MAX_ERRORS
+        assert status.routine_interval_minutes == EXPECTED_INTERVAL
+        assert status.active_member_count == EXPECTED_MEMBER_COUNT
+        assert status.worker_count == EXPECTED_WORKER_COUNT
+    finally:
+        _stop_quietly(service)
+
+
+def test_scheduler_uses_default_routines_when_unspecified(context_factory: Any) -> None:
+    service, _bus = _make_service(context_factory)
+    try:
+        service.start(SchedulerStartRequest(only="scheduler"))
+        assert FakeScheduler.instances[0].routine_commands == DEFAULT_ROUTINES
+        assert service.get_status().scheduler.routine_commands == DEFAULT_ROUTINES
+    finally:
+        _stop_quietly(service)
+
+
+def test_events_metadata_reflects_summary(context_factory: Any) -> None:
+    service, _bus = _make_service(context_factory)
+    try:
+        service.start(SchedulerStartRequest(only="events"))
+        status = service.get_status().events
+        assert status.workflow_command == "workflows/event_driven_workflow"
+        assert status.subscription_count == 1
+        assert status.listener_count == 1
+        assert status.cycle_count == 0
+    finally:
+        _stop_quietly(service)
+
+
+def test_get_status_refreshes_scheduler_cycle_metadata(context_factory: Any) -> None:
+    service, _bus = _make_service(context_factory)
+    try:
+        service.start(SchedulerStartRequest(only="scheduler"))
+        FakeScheduler.instances[0].summary["worker_count"] = REFRESHED_WORKER_COUNT
+        # get_status -> _refresh_locked re-reads the live summary.
+        assert service.get_status().scheduler.worker_count == REFRESHED_WORKER_COUNT
+    finally:
+        _stop_quietly(service)
+
+
+# --------------------------------------------------------------------------- #
+# Stop ordering and success
+# --------------------------------------------------------------------------- #
+
+
+def test_stop_stops_events_before_scheduler(context_factory: Any) -> None:
+    service, bus = _make_service(context_factory)
+    service.start(SchedulerStartRequest())
+
+    order: list[str] = []
+    runner = FakeRunner.instances[0]
+    scheduler = FakeScheduler.instances[0]
+    original_runner_stop = runner.stop
+    original_scheduler_shutdown = scheduler.shutdown
+
+    def tracked_runner_stop() -> None:
+        order.append("events")
+        original_runner_stop()
+
+    def tracked_scheduler_shutdown(graceful: bool = True, timeout: Any = None) -> None:
+        order.append("scheduler")
+        original_scheduler_shutdown(graceful=graceful, timeout=timeout)
+
+    runner.stop = tracked_runner_stop  # type: ignore[method-assign]
+    scheduler.shutdown = tracked_scheduler_shutdown  # type: ignore[method-assign]
+
+    status = service.stop()
+
+    assert order == ["events", "scheduler"]
+    assert status.events.state == "stopped"
+    assert status.events.running is False
+    assert status.scheduler.state == "stopped"
+    assert status.scheduler.running is False
+    # worker_count is zeroed out once the scheduler has stopped.
+    assert status.scheduler.worker_count == 0
+    assert _events_for(bus, "scheduler")[-2:] == [
+        "scheduler.stopping",
+        "scheduler.stopped",
+    ]
+    assert _events_for(bus, "events")[-2:] == ["events.stopping", "events.stopped"]
+
+
+def test_scheduler_shutdown_called_with_stop_timeout(context_factory: Any) -> None:
+    service, _bus = _make_service(context_factory, stop_timeout_seconds=4.5)
+    service.start(SchedulerStartRequest(only="scheduler"))
+    scheduler = FakeScheduler.instances[0]
+
+    service.stop()
+
+    assert scheduler.shutdown_calls == [{"graceful": True, "timeout": 4.5}]
+
+
+# --------------------------------------------------------------------------- #
+# Stop timeout -> failed
+# --------------------------------------------------------------------------- #
+
+
+def test_scheduler_stop_timeout_marks_failed_with_running_true(
+    context_factory: Any,
+) -> None:
+    service, bus = _make_service(context_factory, stop_timeout_seconds=0.1)
+    service.start(SchedulerStartRequest(only="scheduler"))
+    scheduler = FakeScheduler.instances[0]
+    # Prevent the scheduler thread from ever terminating.
+    scheduler.block_shutdown = True
+
+    try:
+        status = service.stop()
+        assert status.scheduler.state == "failed"
+        assert status.scheduler.running is True
+        assert status.scheduler.error == "Scheduler did not stop before timeout."
+        assert "scheduler.failed" in _events_for(bus, "scheduler")
+    finally:
+        scheduler._stop.set()
+
+
+def test_events_stop_timeout_marks_failed_with_running_true(
+    context_factory: Any,
+) -> None:
+    service, bus = _make_service(context_factory, stop_timeout_seconds=0.1)
+    service.start(SchedulerStartRequest(only="events"))
+    runner = FakeRunner.instances[0]
+    # Runner refuses to stop and stays alive past the join timeout.
+    runner.block_stop = True
+
+    status = service.stop()
+
+    assert status.events.state == "failed"
+    assert status.events.running is True
+    assert status.events.error == "Event listener runner did not stop before timeout."
+    assert "events.failed" in _events_for(bus, "events")
+    assert runner.join_calls == [0.1]
+
+
+# --------------------------------------------------------------------------- #
+# context_factory failure
+# --------------------------------------------------------------------------- #
+
+
+def test_scheduler_start_context_factory_exception_marks_failed() -> None:
+    bus = EventBus()
+
+    def boom() -> Any:
+        raise RuntimeError("no context")
+
+    service = lifecycle.RuntimeLifecycleService(
+        event_bus=bus,
+        context_factory=boom,
+        default_routines_factory=lambda: list(DEFAULT_ROUTINES),
+    )
+
+    with pytest.raises(RuntimeError, match="no context"):
+        service.start(SchedulerStartRequest(only="scheduler"))
+
+    status = service.get_status().scheduler
+    assert status.state == "failed"
+    assert status.running is False
+    assert status.error == "no context"
+    assert _events_for(bus, "scheduler") == [
+        "scheduler.starting",
+        "scheduler.failed",
+    ]
+
+
+def test_events_start_context_factory_exception_marks_failed() -> None:
+    bus = EventBus()
+
+    def boom() -> Any:
+        raise RuntimeError("no events context")
+
+    service = lifecycle.RuntimeLifecycleService(
+        event_bus=bus,
+        context_factory=boom,
+        default_routines_factory=lambda: list(DEFAULT_ROUTINES),
+    )
+
+    with pytest.raises(RuntimeError, match="no events context"):
+        service.start(SchedulerStartRequest(only="events"))
+
+    status = service.get_status().events
+    assert status.state == "failed"
+    assert status.running is False
+    assert status.error == "no events context"
+    assert _events_for(bus, "events") == ["events.starting", "events.failed"]
+
+
+# --------------------------------------------------------------------------- #
+# Exception inside the scheduler thread
+# --------------------------------------------------------------------------- #
+
+
+def test_scheduler_thread_exception_reflected_in_failed_event_and_status(
+    context_factory: Any,
+) -> None:
+    service, bus = _make_service(context_factory)
+    bus_before = len(bus.snapshot_events())
+
+    # Patch the next constructed scheduler to raise inside start().
+    original_init = FakeScheduler.__init__
+
+    def patched_init(self: FakeScheduler, *args: Any, **kwargs: Any) -> None:
+        original_init(self, *args, **kwargs)
+        self.start_error = RuntimeError("loop exploded")
+
+    FakeScheduler.__init__ = patched_init  # type: ignore[method-assign]
+    try:
+        service.start(SchedulerStartRequest(only="scheduler"))
+        # The thread runs start() asynchronously; wait for the failed state.
+        assert _wait_until(lambda: service.get_status().scheduler.state == "failed")
+    finally:
+        FakeScheduler.__init__ = original_init  # type: ignore[method-assign]
+
+    status = service.get_status().scheduler
+    assert status.state == "failed"
+    assert status.running is False
+    assert status.error == "loop exploded"
+
+    failed_events = [
+        item
+        for item in bus.snapshot_events()[bus_before:]
+        if item["type"] == "scheduler.failed"
+    ]
+    # The worker publishes a dedicated failure event carrying the traceback.
+    assert any("traceback" in item["payload"] for item in failed_events)
+    assert any(
+        item["payload"].get("error") == "loop exploded" for item in failed_events
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Natural thread termination -> status refresh
+# --------------------------------------------------------------------------- #
+
+
+def test_status_refresh_after_thread_terminates_naturally(
+    context_factory: Any,
+) -> None:
+    service, bus = _make_service(context_factory)
+    service.start(SchedulerStartRequest(only="scheduler"))
+    scheduler = FakeScheduler.instances[0]
+
+    # Let the scheduler loop finish on its own (no stop() call).
+    scheduler._stop.set()
+    assert _wait_until(lambda: service.get_status().scheduler.state == "stopped")
+
+    status = service.get_status().scheduler
+    assert status.state == "stopped"
+    assert status.running is False
+    # Natural completion publishes a stopped event from the worker thread.
+    assert "scheduler.stopped" in _events_for(bus, "scheduler")

--- a/tests/guildbotics/app_api/test_models.py
+++ b/tests/guildbotics/app_api/test_models.py
@@ -1,0 +1,227 @@
+"""Unit tests for ``guildbotics.app_api.models`` and the request models that
+implement the behaviors called out in the test-gap analysis.
+
+The gap analysis references ``MemberTaskSchedule`` and
+``MemberConfigUpdateRequest``; those names do not exist in the codebase. The
+described behaviors (five-field cron validation, blank-schedule exclusion and
+optional secret empty-string handling) are implemented by
+``PersonTaskScheduleInput`` and the project/person update inputs in
+``guildbotics.editions.simple.setup_service``, so they are exercised here.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from guildbotics.app_api.models import (
+    CommandOption,
+    CommandRunRequest,
+    ProjectConfigUpdateRequest,
+    SchedulerStartRequest,
+)
+from guildbotics.editions.simple.setup_service import (
+    PersonTaskScheduleInput,
+    ProjectUpdateInput,
+)
+
+DEFAULT_MAX_CONSECUTIVE_ERRORS = 3
+DEFAULT_ROUTINE_INTERVAL_MINUTES = 10
+
+
+def _project_update_kwargs(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "config_dir": Path("/cfg"),
+        "env_file_path": Path("/cfg/.env"),
+        "language": "en",
+        "llm_api_type": "openai",
+        "cli_agent": "codex",
+        "github_enabled": False,
+    }
+    base.update(overrides)
+    return base
+
+
+# --- PersonTaskScheduleInput (five-field cron / blank handling) -------------
+
+
+def test_task_schedule_accepts_five_field_cron() -> None:
+    schedule = PersonTaskScheduleInput(command="run-it", schedules=["0 9 * * 1"])
+    assert schedule.command == "run-it"
+    assert schedule.schedules == ["0 9 * * 1"]
+
+
+@pytest.mark.parametrize(
+    "expression",
+    [
+        "0 9 * * 1 7",  # six fields
+        "0 9 * *",  # four fields
+        "* * * *",  # four fields
+        "*",  # one field
+    ],
+)
+def test_task_schedule_rejects_non_five_field_cron(expression: str) -> None:
+    with pytest.raises(ValidationError) as exc_info:
+        PersonTaskScheduleInput(command="run-it", schedules=[expression])
+    assert "five-field cron expression" in str(exc_info.value)
+
+
+def test_task_schedule_excludes_blank_schedules() -> None:
+    schedule = PersonTaskScheduleInput(
+        command="run-it",
+        schedules=["   ", "", "0 9 * * 1", "\t"],
+    )
+    # Blank / whitespace-only entries are dropped, valid ones are stripped.
+    assert schedule.schedules == ["0 9 * * 1"]
+
+
+def test_task_schedule_strips_surrounding_whitespace() -> None:
+    schedule = PersonTaskScheduleInput(
+        command="  run-it  ", schedules=["  0 9 * * 1  "]
+    )
+    assert schedule.command == "run-it"
+    assert schedule.schedules == ["0 9 * * 1"]
+
+
+def test_task_schedule_requires_command() -> None:
+    with pytest.raises(ValidationError) as exc_info:
+        PersonTaskScheduleInput(command="   ", schedules=[])
+    assert "command is required" in str(exc_info.value)
+
+
+# --- SchedulerStartRequest validation --------------------------------------
+
+
+def test_scheduler_start_request_defaults() -> None:
+    request = SchedulerStartRequest()
+    assert request.only is None
+    assert request.routine_commands == []
+    assert request.max_consecutive_errors == DEFAULT_MAX_CONSECUTIVE_ERRORS
+    assert request.routine_interval_minutes == DEFAULT_ROUTINE_INTERVAL_MINUTES
+
+
+@pytest.mark.parametrize("only", ["scheduler", "events"])
+def test_scheduler_start_request_accepts_known_only_values(only: str) -> None:
+    request = SchedulerStartRequest(only=only)
+    assert request.only == only
+
+
+@pytest.mark.parametrize("only", ["both", "scheduler ", "Scheduler", "log"])
+def test_scheduler_start_request_rejects_unknown_only_values(only: str) -> None:
+    with pytest.raises(ValidationError):
+        SchedulerStartRequest(only=only)
+
+
+@pytest.mark.parametrize("value", [0, -1, -100])
+def test_scheduler_start_request_rejects_non_positive_max_errors(value: int) -> None:
+    with pytest.raises(ValidationError):
+        SchedulerStartRequest(max_consecutive_errors=value)
+
+
+@pytest.mark.parametrize("value", [0, -1, -5])
+def test_scheduler_start_request_rejects_non_positive_interval(value: int) -> None:
+    with pytest.raises(ValidationError):
+        SchedulerStartRequest(routine_interval_minutes=value)
+
+
+def test_scheduler_start_request_accepts_minimum_values() -> None:
+    request = SchedulerStartRequest(
+        max_consecutive_errors=1, routine_interval_minutes=1
+    )
+    assert request.max_consecutive_errors == 1
+    assert request.routine_interval_minutes == 1
+
+
+# --- Path JSON serialization -----------------------------------------------
+
+
+def test_command_run_request_serializes_path_to_json_string() -> None:
+    request = CommandRunRequest(command="hello", cwd=Path("/tmp/work dir"))
+    payload = json.loads(request.model_dump_json())
+    assert payload["cwd"] == "/tmp/work dir"
+    assert isinstance(payload["cwd"], str)
+
+
+def test_command_run_request_serializes_none_cwd() -> None:
+    request = CommandRunRequest(command="hello")
+    payload = json.loads(request.model_dump_json())
+    assert payload["cwd"] is None
+
+
+def test_command_option_serializes_path_to_json_string() -> None:
+    option = CommandOption(
+        command="hello",
+        label="Hello",
+        category="custom",
+        source="workspace",
+        path=Path("/cfg/commands/hello.md"),
+    )
+    payload = json.loads(option.model_dump_json())
+    assert payload["path"] == "/cfg/commands/hello.md"
+    assert isinstance(payload["path"], str)
+
+
+def test_command_run_request_requires_non_empty_command() -> None:
+    with pytest.raises(ValidationError):
+        CommandRunRequest(command="")
+
+
+# --- Optional secret empty-string handling ---------------------------------
+
+
+def test_project_config_update_request_secrets_default_to_none() -> None:
+    request = ProjectConfigUpdateRequest(
+        config_dir=Path("/cfg"),
+        env_file_path=Path("/cfg/.env"),
+        language="en",
+        llm_api_type="openai",
+        cli_agent="codex",
+        github_enabled=False,
+    )
+    assert request.google_api_key is None
+    assert request.openai_api_key is None
+    assert request.anthropic_api_key is None
+
+
+def test_project_config_update_request_preserves_empty_string_secret() -> None:
+    request = ProjectConfigUpdateRequest(
+        config_dir=Path("/cfg"),
+        env_file_path=Path("/cfg/.env"),
+        language="en",
+        llm_api_type="openai",
+        cli_agent="codex",
+        github_enabled=False,
+        openai_api_key="",
+        google_api_key="value",
+    )
+    # Empty string is preserved distinctly from None (callers treat "" as
+    # "clear the secret" and None as "leave unchanged").
+    assert request.openai_api_key == ""
+    assert request.google_api_key == "value"
+    assert request.anthropic_api_key is None
+
+
+def test_project_update_input_secrets_default_to_none() -> None:
+    request = ProjectUpdateInput(**_project_update_kwargs())
+    assert request.google_api_key is None
+    assert request.openai_api_key is None
+    assert request.anthropic_api_key is None
+
+
+def test_project_update_input_preserves_empty_string_secret() -> None:
+    request = ProjectUpdateInput(
+        **_project_update_kwargs(anthropic_api_key="", openai_api_key="token")
+    )
+    assert request.anthropic_api_key == ""
+    assert request.openai_api_key == "token"
+    assert request.google_api_key is None
+
+
+def test_project_update_input_serializes_path_to_json_string() -> None:
+    request = ProjectUpdateInput(**_project_update_kwargs())
+    payload = json.loads(request.model_dump_json())
+    assert payload["config_dir"] == "/cfg"
+    assert payload["env_file_path"] == "/cfg/.env"

--- a/tests/guildbotics/app_api/test_runtime_commands.py
+++ b/tests/guildbotics/app_api/test_runtime_commands.py
@@ -1,0 +1,760 @@
+"""Direct unit tests for the command / scheduler methods of ``AppRuntime``.
+
+Scope (session S4):
+
+- ``AppRuntime.get_command_options``
+- ``AppRuntime.run_command``
+- ``AppRuntime.start_scheduler``
+
+These complement the coarser API-level tests in ``test_api.py`` with
+finer-grained assertions on file-resolution precedence, argument /
+requirement extraction, published events, the run reservation lock and
+routine rejection. Command execution and context creation are stubbed so
+no real LLM / GitHub / subprocess I/O runs.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from guildbotics.app_api.errors import AppApiError
+from guildbotics.app_api.events import EventBus
+from guildbotics.app_api.models import (
+    CommandRunRequest,
+    SchedulerStartRequest,
+)
+from guildbotics.app_api.runtime import AppRuntime
+from guildbotics.commands.errors import (
+    CommandError,
+    PersonNotFoundError,
+    PersonSelectionRequiredError,
+)
+
+HTTP_BAD_REQUEST = 400
+HTTP_CONFLICT = 409
+
+
+def _make_person(person_id: str = "bot", name: str = "Bot") -> object:
+    return type("PersonStub", (), {"person_id": person_id, "name": name})()
+
+
+def _make_context(
+    members: list[object],
+    *,
+    language_code: str = "en",
+    github_enabled: bool = False,
+) -> object:
+    person = members[0]
+    project = type(
+        "ProjectStub",
+        (),
+        {
+            "get_language_code": lambda self: language_code,
+            "is_available_service": lambda self, service: github_enabled,
+        },
+    )()
+    team = type("TeamStub", (), {"project": project, "members": members})()
+
+    def clone_for(self: object, selected: object) -> object:
+        return _make_context(
+            [selected],
+            language_code=language_code,
+            github_enabled=github_enabled,
+        )
+
+    return type(
+        "ContextStub",
+        (),
+        {"team": team, "person": person, "clone_for": clone_for},
+    )()
+
+
+def _runtime_with_context(
+    monkeypatch: pytest.MonkeyPatch, context: object
+) -> AppRuntime:
+    runtime = AppRuntime(EventBus())
+    monkeypatch.setattr(runtime, "_get_context", lambda message="": context)
+    return runtime
+
+
+def _isolate_workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point cwd / HOME at ``tmp_path`` so command discovery is deterministic."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.delenv("GUILDBOTICS_CONFIG_DIR", raising=False)
+    return tmp_path / ".guildbotics/config"
+
+
+def _write(path: Path, content: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# get_command_options
+# ---------------------------------------------------------------------------
+
+
+def test_command_options_prefers_workspace_over_home_source(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_dir = _isolate_workspace(tmp_path, monkeypatch)
+    home_dir = tmp_path / "home/.guildbotics/config"
+    _write(
+        home_dir / "commands/shared.md",
+        "\n".join(["---", "name: Home Shared", "brain: none", "---", "Home body."]),
+    )
+    _write(
+        config_dir / "commands/shared.md",
+        "\n".join(
+            ["---", "name: Workspace Shared", "brain: none", "---", "Workspace body."]
+        ),
+    )
+    context = _make_context([_make_person()])
+    runtime = _runtime_with_context(monkeypatch, context)
+
+    option = next(
+        item
+        for item in runtime.get_command_options().options
+        if item.command == "shared"
+    )
+
+    assert option.label == "Workspace Shared"
+    assert option.source == "workspace"
+
+
+def test_command_options_prefers_member_specific_command(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_dir = _isolate_workspace(tmp_path, monkeypatch)
+    _write(
+        config_dir / "commands/greet.md",
+        "\n".join(["---", "name: Shared Greet", "brain: none", "---", "Shared."]),
+    )
+    _write(
+        config_dir / "team/members/bot/commands/greet.md",
+        "\n".join(["---", "name: Member Greet", "brain: none", "---", "Member."]),
+    )
+    context = _make_context([_make_person()])
+    runtime = _runtime_with_context(monkeypatch, context)
+
+    option = next(
+        item
+        for item in runtime.get_command_options().options
+        if item.command == "greet"
+    )
+
+    assert option.label == "Member Greet"
+
+
+def test_command_options_localized_file_precedence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_dir = _isolate_workspace(tmp_path, monkeypatch)
+    _write(
+        config_dir / "commands/note.md",
+        "\n".join(["---", "name: Base Note", "brain: none", "---", "Base."]),
+    )
+    _write(
+        config_dir / "commands/note.en.md",
+        "\n".join(["---", "name: English Note", "brain: none", "---", "English."]),
+    )
+    _write(
+        config_dir / "commands/note.ja.md",
+        "\n".join(["---", "name: Japanese Note", "brain: none", "---", "Japanese."]),
+    )
+    context = _make_context([_make_person()], language_code="ja")
+    runtime = _runtime_with_context(monkeypatch, context)
+
+    option = next(
+        item for item in runtime.get_command_options().options if item.command == "note"
+    )
+
+    # `.ja` ranks above `.en`, which ranks above the base file.
+    assert option.label == "Japanese Note"
+
+
+def test_command_options_localized_falls_back_to_english(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_dir = _isolate_workspace(tmp_path, monkeypatch)
+    _write(
+        config_dir / "commands/note.md",
+        "\n".join(["---", "name: Base Note", "brain: none", "---", "Base."]),
+    )
+    _write(
+        config_dir / "commands/note.en.md",
+        "\n".join(["---", "name: English Note", "brain: none", "---", "English."]),
+    )
+    # Requested language is `de`; only `.en` and base exist -> `.en` wins.
+    context = _make_context([_make_person()], language_code="de")
+    runtime = _runtime_with_context(monkeypatch, context)
+
+    option = next(
+        item for item in runtime.get_command_options().options if item.command == "note"
+    )
+
+    assert option.label == "English Note"
+
+
+def test_command_options_extract_python_signature_arguments(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_dir = _isolate_workspace(tmp_path, monkeypatch)
+    _write(
+        config_dir / "commands/run_job.py",
+        "\n".join(
+            [
+                "async def main(context, title, count='3', *, dry_run='false'):",
+                '    """Run a job."""',
+                "    return title",
+            ]
+        ),
+    )
+    context = _make_context([_make_person()])
+    runtime = _runtime_with_context(monkeypatch, context)
+
+    option = next(
+        item
+        for item in runtime.get_command_options().options
+        if item.command == "run_job"
+    )
+
+    assert option.description == "Run a job."
+    assert option.recommended_input == "args"
+    assert [
+        (arg.name, arg.kind, arg.required, arg.default) for arg in option.arguments
+    ] == [
+        ("title", "positional", True, ""),
+        ("count", "positional", False, "3"),
+        ("dry_run", "keyword", False, "false"),
+    ]
+
+
+def test_command_options_extract_yaml_frontmatter_arguments(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_dir = _isolate_workspace(tmp_path, monkeypatch)
+    _write(
+        config_dir / "commands/yaml_task.yml",
+        "\n".join(
+            [
+                "description: Convert ${1} using ${format}.",
+                "commands:",
+                "  - print: done",
+            ]
+        ),
+    )
+    context = _make_context([_make_person()])
+    runtime = _runtime_with_context(monkeypatch, context)
+
+    option = next(
+        item
+        for item in runtime.get_command_options().options
+        if item.command == "yaml_task"
+    )
+
+    assert [(arg.name, arg.kind) for arg in option.arguments] == [
+        ("1", "positional"),
+        ("format", "keyword"),
+    ]
+
+
+def test_command_options_detect_github_and_slack_requirements(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_dir = _isolate_workspace(tmp_path, monkeypatch)
+    monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
+    monkeypatch.delenv("SLACK_APP_TOKEN", raising=False)
+    _write(
+        config_dir / "commands/integrations.py",
+        "\n".join(
+            [
+                "from guildbotics.integrations.ticket_manager import TicketManager",
+                "from guildbotics.integrations.chat_service import ChatService",
+                "",
+                "async def main(context):",
+                "    return ''",
+            ]
+        ),
+    )
+    context = _make_context([_make_person()], github_enabled=True)
+    runtime = _runtime_with_context(monkeypatch, context)
+
+    option = next(
+        item
+        for item in runtime.get_command_options().options
+        if item.command == "integrations"
+    )
+    requirements = {req.kind: req for req in option.requirements}
+
+    assert set(requirements) == {"github", "slack"}
+    # github_enabled context -> github requirement is satisfied.
+    assert requirements["github"].satisfied is True
+    assert requirements["github"].message == "GitHub integration is required."
+    # Slack tokens missing -> unsatisfied.
+    assert requirements["slack"].satisfied is False
+
+
+def test_command_options_detect_llm_and_cli_requirements(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_dir = _isolate_workspace(tmp_path, monkeypatch)
+    _write(
+        config_dir / "commands/llm_task.md",
+        "\n".join(["---", "name: LLM Task", "---", "Summarize ${input}."]),
+    )
+    _write(
+        config_dir / "commands/cli_task.md",
+        "\n".join(["---", "name: CLI Task", "brain: cli", "---", "Edit ${file}."]),
+    )
+    context = _make_context([_make_person()])
+    runtime = _runtime_with_context(monkeypatch, context)
+
+    options = {item.command: item for item in runtime.get_command_options().options}
+
+    assert {req.kind for req in options["llm_task"].requirements} == {"llm"}
+    assert {req.kind for req in options["cli_task"].requirements} == {"cli_agent"}
+
+
+def test_command_options_ignore_invalid_metadata_without_crashing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_dir = _isolate_workspace(tmp_path, monkeypatch)
+    # Broken YAML and unparseable Python must not abort discovery.
+    _write(config_dir / "commands/broken.yml", "::: not: valid: yaml:::\n- [")
+    _write(config_dir / "commands/broken.py", "def main(:\n    pass")
+    _write(
+        config_dir / "commands/ok.md",
+        "\n".join(["---", "name: Ok", "brain: none", "---", "Body."]),
+    )
+    context = _make_context([_make_person()])
+    runtime = _runtime_with_context(monkeypatch, context)
+
+    options = {item.command: item for item in runtime.get_command_options().options}
+
+    assert "ok" in options
+    # Invalid files are still listed but yield empty metadata / no requirements.
+    assert options["broken"].requirements == []
+    assert options["broken"].arguments == []
+
+
+def test_command_options_person_not_found_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _isolate_workspace(tmp_path, monkeypatch)
+    context = _make_context([_make_person("bot", "Bot")])
+    runtime = _runtime_with_context(monkeypatch, context)
+
+    with pytest.raises(AppApiError) as exc_info:
+        runtime.get_command_options(person="missing")
+
+    assert exc_info.value.code == "person_not_found"
+    assert exc_info.value.context["identifier"] == "missing"
+    assert exc_info.value.context["available"] == ["bot"]
+
+
+def test_command_options_member_scope_uses_cloned_context(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_dir = _isolate_workspace(tmp_path, monkeypatch)
+    _write(
+        config_dir / "team/members/alice/commands/private.md",
+        "\n".join(["---", "name: Alice Only", "brain: none", "---", "Body."]),
+    )
+    members = [_make_person("bot", "Bot"), _make_person("alice", "Alice")]
+    context = _make_context(members)
+    runtime = _runtime_with_context(monkeypatch, context)
+
+    # Without scoping to alice, bot's command roots do not include alice's dir.
+    bot_commands = {
+        item.command for item in runtime.get_command_options(person="bot").options
+    }
+    alice_commands = {
+        item.command for item in runtime.get_command_options(person="alice").options
+    }
+
+    assert "private" not in bot_commands
+    assert "private" in alice_commands
+
+
+# ---------------------------------------------------------------------------
+# run_command
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_command_publishes_started_and_finished_events(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    event_bus = EventBus()
+    runtime = AppRuntime(event_bus)
+
+    async def fake_run_command(*_: Any, **__: Any) -> str:
+        return "output-value"
+
+    monkeypatch.setattr(runtime, "_get_context", lambda message="": object())
+    monkeypatch.setattr("guildbotics.app_api.runtime.run_command", fake_run_command)
+
+    response = await runtime.run_command(
+        CommandRunRequest(command="demo", person="bot")
+    )
+
+    assert response.output == "output-value"
+    events = event_bus.snapshot_events()
+    assert [event["type"] for event in events] == [
+        "command.started",
+        "command.finished",
+    ]
+    assert events[0]["payload"] == {"command": "demo", "person": "bot"}
+    assert events[1]["payload"] == {
+        "command": "demo",
+        "output_length": len("output-value"),
+    }
+    assert {event["request_id"] for event in events} == {response.request_id}
+
+
+@pytest.mark.asyncio
+async def test_run_command_passes_cwd_and_args_into_execution(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    runtime = AppRuntime(EventBus())
+    captured: dict[str, Any] = {}
+    sentinel_context = object()
+
+    async def fake_run_command(context: object, **kwargs: Any) -> str:
+        captured["context"] = context
+        captured.update(kwargs)
+        return "ok"
+
+    monkeypatch.setattr(runtime, "_get_context", lambda message="": sentinel_context)
+    monkeypatch.setattr("guildbotics.app_api.runtime.run_command", fake_run_command)
+
+    await runtime.run_command(
+        CommandRunRequest(
+            command="demo",
+            args=["one", "two"],
+            person="bot",
+            cwd=tmp_path,
+        )
+    )
+
+    assert captured["context"] is sentinel_context
+    assert captured["command_name"] == "demo"
+    assert captured["command_args"] == ["one", "two"]
+    assert captured["person_identifier"] == "bot"
+    assert captured["cwd"] == tmp_path
+
+
+@pytest.mark.asyncio
+async def test_run_command_log_handler_publishes_request_tagged_events(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    event_bus = EventBus()
+    runtime = AppRuntime(event_bus)
+    guildbotics_logger = logging.getLogger("guildbotics")
+    monkeypatch.setattr(guildbotics_logger, "level", logging.INFO)
+
+    async def fake_run_command(*_: Any, **__: Any) -> str:
+        guildbotics_logger.info("progress message")
+        return "done"
+
+    monkeypatch.setattr(runtime, "_get_context", lambda message="": object())
+    monkeypatch.setattr("guildbotics.app_api.runtime.run_command", fake_run_command)
+
+    response = await runtime.run_command(CommandRunRequest(command="demo"))
+
+    events = event_bus.snapshot_events()
+    log_events = [event for event in events if event["type"] == "command.log"]
+    assert len(log_events) == 1
+    assert log_events[0]["payload"] == {
+        "level": "INFO",
+        "message": "progress message",
+    }
+    assert log_events[0]["request_id"] == response.request_id
+    # The handler is removed afterwards: a later log produces no new event.
+    guildbotics_logger.info("after run")
+    assert event_bus.snapshot_events() == events
+
+
+@pytest.mark.asyncio
+async def test_run_command_publishes_failed_event_for_person_selection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    event_bus = EventBus()
+    runtime = AppRuntime(event_bus)
+
+    async def fake_run_command(*_: Any, **__: Any) -> str:
+        raise PersonSelectionRequiredError(["bot", "alice"])
+
+    monkeypatch.setattr(runtime, "_get_context", lambda message="": object())
+    monkeypatch.setattr("guildbotics.app_api.runtime.run_command", fake_run_command)
+
+    with pytest.raises(AppApiError) as exc_info:
+        await runtime.run_command(CommandRunRequest(command="demo"))
+
+    assert exc_info.value.code == "person_selection_required"
+    assert exc_info.value.context["available"] == ["bot", "alice"]
+    failed = [
+        event
+        for event in event_bus.snapshot_events()
+        if event["type"] == "command.failed"
+    ]
+    assert len(failed) == 1
+    assert failed[0]["payload"] == {
+        "command": "demo",
+        "code": "person_selection_required",
+        "available": ["bot", "alice"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_run_command_publishes_failed_event_for_person_not_found(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    event_bus = EventBus()
+    runtime = AppRuntime(event_bus)
+
+    async def fake_run_command(*_: Any, **__: Any) -> str:
+        raise PersonNotFoundError("ghost", ["bot"])
+
+    monkeypatch.setattr(runtime, "_get_context", lambda message="": object())
+    monkeypatch.setattr("guildbotics.app_api.runtime.run_command", fake_run_command)
+
+    with pytest.raises(AppApiError) as exc_info:
+        await runtime.run_command(CommandRunRequest(command="demo", person="ghost"))
+
+    assert exc_info.value.code == "person_not_found"
+    assert exc_info.value.context == {"identifier": "ghost", "available": ["bot"]}
+    failed = [
+        event
+        for event in event_bus.snapshot_events()
+        if event["type"] == "command.failed"
+    ]
+    assert failed[0]["payload"] == {
+        "command": "demo",
+        "code": "person_not_found",
+        "identifier": "ghost",
+        "available": ["bot"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_run_command_publishes_failed_event_for_command_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    event_bus = EventBus()
+    runtime = AppRuntime(event_bus)
+
+    async def fake_run_command(*_: Any, **__: Any) -> str:
+        raise CommandError("boom")
+
+    monkeypatch.setattr(runtime, "_get_context", lambda message="": object())
+    monkeypatch.setattr("guildbotics.app_api.runtime.run_command", fake_run_command)
+
+    with pytest.raises(AppApiError) as exc_info:
+        await runtime.run_command(CommandRunRequest(command="demo"))
+
+    assert exc_info.value.code == "command_error"
+    assert exc_info.value.message == "boom"
+    failed = [
+        event
+        for event in event_bus.snapshot_events()
+        if event["type"] == "command.failed"
+    ]
+    assert failed[0]["payload"] == {
+        "command": "demo",
+        "code": "command_error",
+        "message": "boom",
+    }
+
+
+@pytest.mark.asyncio
+async def test_run_command_publishes_failed_event_for_unexpected_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    event_bus = EventBus()
+    runtime = AppRuntime(event_bus)
+
+    async def fake_run_command(*_: Any, **__: Any) -> str:
+        raise ValueError("unexpected")
+
+    monkeypatch.setattr(runtime, "_get_context", lambda message="": object())
+    monkeypatch.setattr("guildbotics.app_api.runtime.run_command", fake_run_command)
+
+    with pytest.raises(ValueError, match="unexpected"):
+        await runtime.run_command(CommandRunRequest(command="demo"))
+
+    failed = [
+        event
+        for event in event_bus.snapshot_events()
+        if event["type"] == "command.failed"
+    ]
+    assert failed[0]["payload"] == {"command": "demo", "error_type": "ValueError"}
+
+
+@pytest.mark.asyncio
+async def test_run_command_releases_reservation_after_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = AppRuntime(EventBus())
+    attempts: list[str] = []
+
+    async def fake_run_command(*_: Any, **__: Any) -> str:
+        attempts.append("called")
+        if len(attempts) == 1:
+            raise CommandError("first failure")
+        return "second ok"
+
+    monkeypatch.setattr(runtime, "_get_context", lambda message="": object())
+    monkeypatch.setattr("guildbotics.app_api.runtime.run_command", fake_run_command)
+
+    with pytest.raises(AppApiError):
+        await runtime.run_command(CommandRunRequest(command="demo"))
+
+    # Reservation must be released so a subsequent run is accepted (not 409).
+    response = await runtime.run_command(CommandRunRequest(command="demo"))
+
+    assert response.output == "second ok"
+    assert attempts == ["called", "called"]
+
+
+@pytest.mark.asyncio
+async def test_run_command_releases_reservation_after_unexpected_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = AppRuntime(EventBus())
+    attempts: list[str] = []
+
+    async def fake_run_command(*_: Any, **__: Any) -> str:
+        attempts.append("called")
+        if len(attempts) == 1:
+            raise RuntimeError("crash")
+        return "recovered"
+
+    monkeypatch.setattr(runtime, "_get_context", lambda message="": object())
+    monkeypatch.setattr("guildbotics.app_api.runtime.run_command", fake_run_command)
+
+    with pytest.raises(RuntimeError, match="crash"):
+        await runtime.run_command(CommandRunRequest(command="demo"))
+
+    response = await runtime.run_command(CommandRunRequest(command="demo"))
+
+    assert response.output == "recovered"
+
+
+@pytest.mark.asyncio
+async def test_run_command_rejects_concurrent_run_with_conflict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = AppRuntime(EventBus())
+    # Simulate an in-flight command by holding the reservation.
+    runtime._reserve_command("inflight-id")
+
+    monkeypatch.setattr(runtime, "_get_context", lambda message="": object())
+
+    with pytest.raises(AppApiError) as exc_info:
+        await runtime.run_command(CommandRunRequest(command="demo"))
+
+    assert exc_info.value.code == "command_already_running"
+    assert exc_info.value.status_code == HTTP_CONFLICT
+    assert exc_info.value.context == {"request_id": "inflight-id"}
+
+
+# ---------------------------------------------------------------------------
+# start_scheduler
+# ---------------------------------------------------------------------------
+
+
+def test_start_scheduler_rejects_github_required_custom_routine(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = AppRuntime(EventBus())
+    monkeypatch.setattr(runtime, "is_github_integration_enabled", lambda: False)
+    monkeypatch.setattr(
+        runtime,
+        "requires_github_for_routine",
+        lambda command: command == "workflows/needs_github",
+    )
+
+    with pytest.raises(AppApiError) as exc_info:
+        runtime.start_scheduler(
+            SchedulerStartRequest(routine_commands=["workflows/needs_github"])
+        )
+
+    assert exc_info.value.code == "github_integration_required_for_routine"
+    assert exc_info.value.status_code == HTTP_BAD_REQUEST
+    assert exc_info.value.context == {"command": "workflows/needs_github"}
+
+
+def test_start_scheduler_allows_non_github_custom_routine(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = AppRuntime(EventBus())
+    started: dict[str, Any] = {}
+    monkeypatch.setattr(runtime, "is_github_integration_enabled", lambda: False)
+    monkeypatch.setattr(runtime, "requires_github_for_routine", lambda command: False)
+    monkeypatch.setattr(
+        runtime._lifecycle,
+        "start",
+        lambda request: started.update(routines=request.routine_commands) or "status",
+    )
+
+    result = runtime.start_scheduler(
+        SchedulerStartRequest(routine_commands=["workflows/local_only"])
+    )
+
+    assert result == "status"
+    assert started["routines"] == ["workflows/local_only"]
+
+
+def test_start_scheduler_uses_default_routines_when_none_requested(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = AppRuntime(EventBus())
+    checked: list[str] = []
+
+    class EditionStub:
+        def get_default_routines(self) -> list[str]:
+            return ["workflows/ticket_driven_workflow"]
+
+    monkeypatch.setattr(
+        "guildbotics.app_api.runtime.get_edition", lambda: EditionStub()
+    )
+    monkeypatch.setattr(runtime, "is_github_integration_enabled", lambda: False)
+    monkeypatch.setattr(
+        runtime,
+        "requires_github_for_routine",
+        lambda command: checked.append(command) or False,
+    )
+    monkeypatch.setattr(runtime._lifecycle, "start", lambda request: "status")
+
+    runtime.start_scheduler(SchedulerStartRequest())
+
+    # Default routines are consulted for requirement detection.
+    assert checked == ["workflows/ticket_driven_workflow"]
+
+
+def test_start_scheduler_skips_routine_check_for_events_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = AppRuntime(EventBus())
+
+    def fail_default_routines() -> list[str]:  # pragma: no cover - must not run
+        raise AssertionError("default routines must not be consulted for events only")
+
+    monkeypatch.setattr(
+        "guildbotics.app_api.runtime.get_edition",
+        lambda: type("E", (), {"get_default_routines": fail_default_routines})(),
+    )
+    monkeypatch.setattr(runtime, "is_github_integration_enabled", lambda: False)
+    monkeypatch.setattr(runtime._lifecycle, "start", lambda request: "events-status")
+
+    result = runtime.start_scheduler(SchedulerStartRequest(only="events"))
+
+    assert result == "events-status"

--- a/tests/guildbotics/app_api/test_runtime_config.py
+++ b/tests/guildbotics/app_api/test_runtime_config.py
@@ -1,0 +1,473 @@
+"""Direct unit tests for the config / workspace / team / prompt-trace /
+cli-agent-detection behaviors of :class:`guildbotics.app_api.runtime.AppRuntime`.
+
+These exercise finer branch granularity than the API-level tests in
+``test_api.py``: each method is driven directly with ``tmp_path`` and
+``monkeypatch`` so that env, cwd, HOME, and scheduler interactions are isolated
+and never touch the real home directory or network.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from guildbotics.app_api.errors import AppApiError
+from guildbotics.app_api.events import EventBus
+from guildbotics.app_api.models import PromptTraceUpdateRequest
+from guildbotics.app_api.runtime import AppRuntime
+
+HTTP_BAD_REQUEST = 400
+TRACE_EVENT_TOTAL = 5
+TRACE_EVENT_LIMIT = 2
+
+
+@pytest.fixture
+def isolated_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point cwd and HOME at the tmp tree and clear config overrides."""
+    monkeypatch.chdir(tmp_path)
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("GUILDBOTICS_CONFIG_DIR", raising=False)
+    return tmp_path
+
+
+@pytest.fixture(autouse=True)
+def _restore_cwd() -> object:
+    """Restore the working directory even if a test calls ``os.chdir``."""
+    original = Path.cwd()
+    yield
+    os.chdir(original)
+
+
+def _write_project(config_dir: Path, body: str = "language: en\n") -> Path:
+    project_file = config_dir / "team" / "project.yml"
+    project_file.parent.mkdir(parents=True, exist_ok=True)
+    project_file.write_text(body)
+    return project_file
+
+
+# --- get_config_status() ----------------------------------------------------
+
+
+def test_config_status_reports_workspace_when_workspace_config_present(
+    isolated_home: Path,
+) -> None:
+    _write_project(isolated_home / ".guildbotics" / "config")
+
+    status = AppRuntime(EventBus()).get_config_status()
+
+    assert status.cwd == isolated_home
+    assert status.primary_config_dir == isolated_home / ".guildbotics" / "config"
+    assert status.primary_config_location == "workspace"
+    assert status.primary_project_file_exists is True
+    assert status.active_config_dir == isolated_home / ".guildbotics" / "config"
+    assert status.active_config_location == "workspace"
+
+
+def test_config_status_falls_back_to_home_config(isolated_home: Path) -> None:
+    home_config = isolated_home / "home" / ".guildbotics" / "config"
+    _write_project(home_config)
+
+    status = AppRuntime(EventBus()).get_config_status()
+
+    assert status.home_project_file_exists is True
+    assert status.primary_project_file_exists is False
+    assert status.active_config_dir == home_config
+    assert status.active_config_location == "home"
+
+
+def test_config_status_uses_custom_config_dir_env(
+    isolated_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    custom_config = isolated_home / "custom-config"
+    _write_project(custom_config)
+    monkeypatch.setenv("GUILDBOTICS_CONFIG_DIR", str(custom_config))
+
+    status = AppRuntime(EventBus()).get_config_status()
+
+    assert status.primary_config_dir == custom_config
+    assert status.primary_config_location == "custom"
+    assert status.active_config_dir == custom_config
+    assert status.active_config_location == "custom"
+
+
+def test_config_status_reports_missing_when_no_project_file(
+    isolated_home: Path,
+) -> None:
+    status = AppRuntime(EventBus()).get_config_status()
+
+    assert status.primary_project_file_exists is False
+    assert status.home_project_file_exists is False
+    assert status.active_config_dir is None
+    assert status.active_config_location == "missing"
+    assert status.env_file == isolated_home / ".env"
+    assert status.env_file_exists is False
+
+
+def test_config_status_detects_existing_env_file(isolated_home: Path) -> None:
+    (isolated_home / ".env").write_text("OPENAI_API_KEY=value\n")
+
+    status = AppRuntime(EventBus()).get_config_status()
+
+    assert status.env_file_exists is True
+
+
+# --- set_workspace() --------------------------------------------------------
+
+
+def test_set_workspace_raises_for_missing_path(isolated_home: Path) -> None:
+    runtime = AppRuntime(EventBus())
+    missing = isolated_home / "does-not-exist"
+
+    with pytest.raises(AppApiError) as exc_info:
+        runtime.set_workspace(missing)
+
+    assert exc_info.value.code == "workspace_not_found"
+    assert exc_info.value.status_code == HTTP_BAD_REQUEST
+    assert exc_info.value.context == {"workspace_dir": str(missing.resolve())}
+
+
+def test_set_workspace_raises_for_file_path(isolated_home: Path) -> None:
+    runtime = AppRuntime(EventBus())
+    file_path = isolated_home / "workspace-file"
+    file_path.write_text("not a dir")
+
+    with pytest.raises(AppApiError) as exc_info:
+        runtime.set_workspace(file_path)
+
+    assert exc_info.value.code == "workspace_not_directory"
+    assert exc_info.value.status_code == HTTP_BAD_REQUEST
+
+
+def test_set_workspace_stops_scheduler_changes_cwd_and_loads_env(
+    isolated_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runtime = AppRuntime(EventBus())
+    stop_calls: list[bool] = []
+    monkeypatch.setattr(
+        runtime, "stop_scheduler", lambda: stop_calls.append(True) or None
+    )
+    monkeypatch.delenv("WORKSPACE_MARKER", raising=False)
+
+    workspace = isolated_home / "workspace"
+    workspace.mkdir()
+    _write_project(workspace / ".guildbotics" / "config")
+    (workspace / ".env").write_text("WORKSPACE_MARKER=loaded\n")
+
+    status = runtime.set_workspace(workspace)
+
+    assert stop_calls == [True]
+    assert Path.cwd() == workspace.resolve()
+    assert os.environ["WORKSPACE_MARKER"] == "loaded"
+    assert status.cwd == workspace.resolve()
+    assert status.primary_config_location == "workspace"
+    assert status.active_config_location == "workspace"
+    assert status.env_file_exists is True
+
+
+# --- get_team_summary() -----------------------------------------------------
+
+
+class _ProjectStub:
+    name = "GuildBotics"
+
+    def get_language_code(self) -> str:
+        return "ja"
+
+    def get_language_name(self) -> str:
+        return "日本語"
+
+
+class _MemberStub:
+    def __init__(
+        self, person_id: str, name: str, is_active: bool, roles: dict[str, object]
+    ) -> None:
+        self.person_id = person_id
+        self.name = name
+        self.is_active = is_active
+        self.roles = roles
+
+
+def _context_with_members(members: list[_MemberStub]) -> object:
+    team = type("TeamStub", (), {"project": _ProjectStub(), "members": members})()
+    return type("ContextStub", (), {"team": team})()
+
+
+def test_team_summary_reports_project_language_and_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = AppRuntime(EventBus())
+    context = _context_with_members([])
+    monkeypatch.setattr(runtime, "_get_context", lambda message="": context)
+
+    summary = runtime.get_team_summary()
+
+    assert summary.project.name == "GuildBotics"
+    assert summary.project.language_code == "ja"
+    assert summary.project.language_name == "日本語"
+    assert summary.members == []
+
+
+def test_team_summary_sorts_member_roles(monkeypatch: pytest.MonkeyPatch) -> None:
+    runtime = AppRuntime(EventBus())
+    member = _MemberStub(
+        "alice",
+        "Alice",
+        True,
+        {"reviewer": {}, "architect": {}, "developer": {}},
+    )
+    context = _context_with_members([member])
+    monkeypatch.setattr(runtime, "_get_context", lambda message="": context)
+
+    summary = runtime.get_team_summary()
+
+    assert [member.roles for member in summary.members] == [
+        ["architect", "developer", "reviewer"]
+    ]
+
+
+def test_team_summary_includes_inactive_members(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = AppRuntime(EventBus())
+    members = [
+        _MemberStub("active", "Active", True, {"architect": {}}),
+        _MemberStub("inactive", "Inactive", False, {}),
+    ]
+    context = _context_with_members(members)
+    monkeypatch.setattr(runtime, "_get_context", lambda message="": context)
+
+    summary = runtime.get_team_summary()
+
+    by_id = {member.person_id: member for member in summary.members}
+    assert by_id["active"].is_active is True
+    assert by_id["inactive"].is_active is False
+    assert by_id["inactive"].roles == []
+
+
+# --- prompt trace -----------------------------------------------------------
+
+
+def test_prompt_trace_status_reflects_limit_and_read_path(
+    isolated_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("GUILDBOTICS_PROMPT_TRACE", "1")
+    monkeypatch.delenv("GUILDBOTICS_PROMPT_TRACE_PATH", raising=False)
+    output_trace = isolated_home / "output.jsonl"
+    monkeypatch.setenv("GUILDBOTICS_PROMPT_TRACE_PATH", str(output_trace))
+    read_trace = isolated_home / "history.jsonl"
+    read_trace.write_text(
+        "\n".join(
+            f'{{"event":"llm.request","timestamp":"t{index}",'
+            f'"person_id":"p{index}","message":"m{index}"}}'
+            for index in range(5)
+        )
+        + "\n"
+    )
+    runtime = AppRuntime(EventBus())
+
+    status = runtime.get_prompt_trace_status(limit=2, read_path=str(read_trace))
+
+    assert status.enabled is True
+    assert status.trace_file == read_trace
+    assert status.output_trace_file == output_trace
+    assert status.trace_file_exists is True
+    assert status.event_count == TRACE_EVENT_TOTAL
+    assert len(status.events) == TRACE_EVENT_LIMIT
+    # The reader returns the most recent ``limit`` events, newest first.
+    assert [event.person_id for event in status.events] == ["p4", "p3"]
+
+
+def test_prompt_trace_status_uses_output_path_when_read_path_blank(
+    isolated_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    output_trace = isolated_home / "output.jsonl"
+    output_trace.write_text(
+        '{"event":"llm.request","timestamp":"t","person_id":"p","message":"m"}\n'
+    )
+    monkeypatch.setenv("GUILDBOTICS_PROMPT_TRACE", "0")
+    monkeypatch.setenv("GUILDBOTICS_PROMPT_TRACE_PATH", str(output_trace))
+    runtime = AppRuntime(EventBus())
+
+    status = runtime.get_prompt_trace_status(read_path="   ")
+
+    assert status.enabled is False
+    assert status.trace_file == output_trace
+    assert status.event_count == 1
+
+
+def test_update_prompt_trace_writes_env_and_environ(
+    isolated_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("GUILDBOTICS_PROMPT_TRACE", raising=False)
+    monkeypatch.delenv("GUILDBOTICS_PROMPT_TRACE_PATH", raising=False)
+    trace_path = isolated_home / "trace.jsonl"
+    runtime = AppRuntime(EventBus())
+
+    status = runtime.update_prompt_trace(
+        PromptTraceUpdateRequest(enabled=True, trace_path=f"  {trace_path}  ")
+    )
+
+    assert os.environ["GUILDBOTICS_PROMPT_TRACE"] == "1"
+    assert os.environ["GUILDBOTICS_PROMPT_TRACE_PATH"] == str(trace_path)
+    env_text = (isolated_home / ".env").read_text()
+    assert "GUILDBOTICS_PROMPT_TRACE=1" in env_text
+    assert f"GUILDBOTICS_PROMPT_TRACE_PATH={trace_path}" in env_text
+    assert status.enabled is True
+    assert status.trace_file == trace_path
+
+
+def test_update_prompt_trace_empty_path_removes_env_key(
+    isolated_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("GUILDBOTICS_PROMPT_TRACE_PATH", "/old/trace.jsonl")
+    (isolated_home / ".env").write_text(
+        "GUILDBOTICS_PROMPT_TRACE=1\nGUILDBOTICS_PROMPT_TRACE_PATH=/old/trace.jsonl\n"
+    )
+    runtime = AppRuntime(EventBus())
+
+    runtime.update_prompt_trace(PromptTraceUpdateRequest(enabled=False, trace_path=""))
+
+    assert "GUILDBOTICS_PROMPT_TRACE_PATH" not in os.environ
+    env_text = (isolated_home / ".env").read_text()
+    assert "GUILDBOTICS_PROMPT_TRACE=0" in env_text
+    assert "GUILDBOTICS_PROMPT_TRACE_PATH" not in env_text
+
+
+def test_update_prompt_trace_preserves_existing_keys_and_order(
+    isolated_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("GUILDBOTICS_PROMPT_TRACE", raising=False)
+    (isolated_home / ".env").write_text(
+        "\n".join(
+            [
+                "# leading comment",
+                "OPENAI_API_KEY=first",
+                "GUILDBOTICS_PROMPT_TRACE=0",
+                "EXTRA=keep",
+            ]
+        )
+        + "\n"
+    )
+    trace_path = isolated_home / "trace.jsonl"
+    runtime = AppRuntime(EventBus())
+
+    runtime.update_prompt_trace(
+        PromptTraceUpdateRequest(enabled=True, trace_path=str(trace_path))
+    )
+
+    lines = (isolated_home / ".env").read_text().splitlines()
+    keys = [line.split("=", 1)[0] for line in lines if "=" in line]
+    # Existing keys retain their original relative order; the toggled key is
+    # updated in place and the new path key is appended after them.
+    assert keys == [
+        "OPENAI_API_KEY",
+        "GUILDBOTICS_PROMPT_TRACE",
+        "EXTRA",
+        "GUILDBOTICS_PROMPT_TRACE_PATH",
+    ]
+    env_map = dict(line.split("=", 1) for line in lines if "=" in line)
+    assert env_map["OPENAI_API_KEY"] == "first"
+    assert env_map["GUILDBOTICS_PROMPT_TRACE"] == "1"
+    assert env_map["EXTRA"] == "keep"
+    assert env_map["GUILDBOTICS_PROMPT_TRACE_PATH"] == str(trace_path)
+
+
+# --- detect_cli_agents() ----------------------------------------------------
+
+
+def test_detect_cli_agents_falls_back_when_mapping_load_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _raise(_path: object) -> object:
+        raise RuntimeError("broken mapping")
+
+    monkeypatch.setattr("guildbotics.app_api.runtime.load_yaml_file", _raise)
+    monkeypatch.setattr(
+        "guildbotics.app_api.runtime.load_cli_agent_script",
+        lambda root, info: "",
+    )
+    monkeypatch.setattr(
+        "guildbotics.app_api.runtime.resolve_cli_executable", lambda script: ""
+    )
+    runtime = AppRuntime(EventBus())
+
+    response = runtime.detect_cli_agents()
+
+    assert [agent.name for agent in response.agents] == [
+        "codex",
+        "gemini",
+        "claude",
+        "copilot",
+    ]
+    assert all(agent.executable == "" for agent in response.agents)
+    assert all(agent.detected is False for agent in response.agents)
+    assert all(agent.path == "" for agent in response.agents)
+
+
+def test_detect_cli_agents_resolves_executable_and_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "guildbotics.app_api.runtime.load_yaml_file",
+        lambda path: {
+            "codex": "codex-cli.yml",
+            "gemini": "gemini-cli.yml",
+            "claude": "claude-cli.yml",
+            "copilot": "copilot-cli.yml",
+        },
+    )
+    monkeypatch.setattr(
+        "guildbotics.app_api.runtime.load_cli_agent_script",
+        lambda root, info: f"run {info.split('-', 1)[0]} now",
+    )
+    monkeypatch.setattr(
+        "guildbotics.app_api.runtime.resolve_cli_executable",
+        lambda script: script.split(" ")[1],
+    )
+
+    def _resolve_path(executable: str) -> str:
+        return f"/usr/local/bin/{executable}" if executable == "codex" else ""
+
+    monkeypatch.setattr(
+        "guildbotics.app_api.runtime.resolve_cli_agent_path", _resolve_path
+    )
+    runtime = AppRuntime(EventBus())
+
+    agents = {agent.name: agent for agent in runtime.detect_cli_agents().agents}
+
+    assert agents["codex"].executable == "codex"
+    assert agents["codex"].detected is True
+    assert agents["codex"].path == "/usr/local/bin/codex"
+    assert agents["gemini"].executable == "gemini"
+    assert agents["gemini"].detected is False
+    assert agents["gemini"].path == ""
+
+
+def test_detect_cli_agents_marks_undetected_when_executable_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("guildbotics.app_api.runtime.load_yaml_file", lambda path: {})
+    monkeypatch.setattr(
+        "guildbotics.app_api.runtime.load_cli_agent_script",
+        lambda root, info: "",
+    )
+    monkeypatch.setattr(
+        "guildbotics.app_api.runtime.resolve_cli_executable", lambda script: ""
+    )
+    resolve_calls: list[str] = []
+    monkeypatch.setattr(
+        "guildbotics.app_api.runtime.resolve_cli_agent_path",
+        lambda executable: resolve_calls.append(executable) or "",
+    )
+    runtime = AppRuntime(EventBus())
+
+    response = runtime.detect_cli_agents()
+
+    # With no executable resolved, path resolution is skipped entirely.
+    assert resolve_calls == []
+    assert all(agent.detected is False for agent in response.agents)

--- a/tests/guildbotics/app_api/test_sidecar_smoke.py
+++ b/tests/guildbotics/app_api/test_sidecar_smoke.py
@@ -1,0 +1,194 @@
+"""Smoke tests for the Local API sidecar process.
+
+These tests launch ``python -m guildbotics.app_api`` as a real subprocess
+(the same entrypoint the desktop app spawns), poll ``/health`` until ready,
+and assert basic request handling plus a clean shutdown. They are hermetic:
+the server binds a dynamically chosen free port on ``127.0.0.1`` and uses a
+``tmp_path`` working directory, never the real home directory.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import sys
+import time
+from collections.abc import Iterator
+from pathlib import Path
+
+import httpx
+import pytest
+
+HTTP_OK = 200
+HTTP_UNAUTHORIZED = 401
+
+STARTUP_TIMEOUT_SECONDS = 30.0
+SHUTDOWN_TIMEOUT_SECONDS = 15.0
+POLL_INTERVAL_SECONDS = 0.2
+REQUEST_TIMEOUT_SECONDS = 5.0
+
+TOKEN = "smoke-test-token"
+AUTH_HEADERS = {"X-GuildBotics-Session-Token": TOKEN}
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _can_bind_localhost() -> bool:
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.bind(("127.0.0.1", 0))
+        return True
+    except OSError:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _can_bind_localhost(),
+    reason="Environment cannot bind a local TCP socket.",
+)
+
+
+class _Sidecar:
+    def __init__(self, base_url: str, process: subprocess.Popen[str]) -> None:
+        self.base_url = base_url
+        self.process = process
+
+
+@pytest.fixture
+def sidecar(tmp_path: Path) -> Iterator[_Sidecar]:
+    port = _find_free_port()
+    base_url = f"http://127.0.0.1:{port}"
+    # Fully hermetic: redirect HOME to the tmp tree and drop any inherited config
+    # overrides so the subprocess never reads or writes the real ~/.guildbotics.
+    home = tmp_path / "home"
+    home.mkdir()
+    env = {**os.environ, "HOME": str(home)}
+    for key in (
+        "GUILDBOTICS_CONFIG_DIR",
+        "GUILDBOTICS_PROMPT_TRACE",
+        "GUILDBOTICS_PROMPT_TRACE_PATH",
+    ):
+        env.pop(key, None)
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "guildbotics.app_api",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+            "--token",
+            TOKEN,
+        ],
+        cwd=str(tmp_path),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    try:
+        _wait_for_health(base_url, process)
+        yield _Sidecar(base_url, process)
+    finally:
+        _terminate(process)
+
+
+def _drain_output(process: subprocess.Popen[str]) -> str:
+    if process.stdout is None:
+        return ""
+    try:
+        return process.stdout.read() or ""
+    except ValueError:
+        return ""
+
+
+def _wait_for_health(base_url: str, process: subprocess.Popen[str]) -> None:
+    deadline = time.monotonic() + STARTUP_TIMEOUT_SECONDS
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise AssertionError(
+                "Sidecar exited during startup with code "
+                f"{process.returncode}:\n{_drain_output(process)}"
+            )
+        try:
+            response = httpx.get(
+                f"{base_url}/health",
+                headers=AUTH_HEADERS,
+                timeout=REQUEST_TIMEOUT_SECONDS,
+            )
+            if response.status_code == HTTP_OK:
+                return
+            last_error = AssertionError(
+                f"Unexpected health status {response.status_code}"
+            )
+        except httpx.HTTPError as error:  # not yet accepting connections
+            last_error = error
+        time.sleep(POLL_INTERVAL_SECONDS)
+    _terminate(process)
+    raise AssertionError(f"Sidecar did not become healthy in time: {last_error!r}")
+
+
+def _terminate(process: subprocess.Popen[str]) -> None:
+    if process.poll() is not None:
+        return
+    process.terminate()
+    try:
+        process.wait(timeout=SHUTDOWN_TIMEOUT_SECONDS)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=SHUTDOWN_TIMEOUT_SECONDS)
+
+
+def test_sidecar_health_returns_ok(sidecar: _Sidecar) -> None:
+    response = httpx.get(
+        f"{sidecar.base_url}/health",
+        headers=AUTH_HEADERS,
+        timeout=REQUEST_TIMEOUT_SECONDS,
+    )
+
+    assert response.status_code == HTTP_OK
+    assert response.json() == {"status": "ok"}
+
+
+def test_sidecar_rejects_invalid_token(sidecar: _Sidecar) -> None:
+    response = httpx.get(
+        f"{sidecar.base_url}/health",
+        headers={"X-GuildBotics-Session-Token": "wrong-token"},
+        timeout=REQUEST_TIMEOUT_SECONDS,
+    )
+
+    assert response.status_code == HTTP_UNAUTHORIZED
+    assert response.json()["code"] == "invalid_session_token"
+
+
+def test_sidecar_config_status_reports_working_directory(
+    sidecar: _Sidecar, tmp_path: Path
+) -> None:
+    response = httpx.get(
+        f"{sidecar.base_url}/config/status",
+        headers=AUTH_HEADERS,
+        timeout=REQUEST_TIMEOUT_SECONDS,
+    )
+
+    assert response.status_code == HTTP_OK
+    payload = response.json()
+    assert Path(payload["cwd"]).resolve() == tmp_path.resolve()
+
+
+def test_sidecar_shuts_down_cleanly(sidecar: _Sidecar) -> None:
+    process = sidecar.process
+    assert process.poll() is None  # still running
+
+    process.terminate()
+    return_code = process.wait(timeout=SHUTDOWN_TIMEOUT_SECONDS)
+
+    # SIGTERM-initiated shutdown should not surface as a crash.
+    assert process.poll() is not None
+    assert return_code in {0, -15}

--- a/tests/guildbotics/app_api/test_verify.py
+++ b/tests/guildbotics/app_api/test_verify.py
@@ -1,18 +1,33 @@
 from pathlib import Path
 
+import pytest
+
+from guildbotics.app_api import verify as verify_module
 from guildbotics.app_api.models import ConfigStatus
 from guildbotics.app_api.verify import VerifyService
 from guildbotics.entities.team import Person, Project, Team
 from guildbotics.integrations.github.github_utils import GitHubAppAuth
 
+PROVIDER_ENV_KEYS = (
+    "OPENAI_API_KEY",
+    "GOOGLE_API_KEY",
+    "ANTHROPIC_API_KEY",
+)
 
-def _config_status(tmp_path: Path, *, env_file_exists: bool = True) -> ConfigStatus:
+
+def _config_status(
+    tmp_path: Path,
+    *,
+    env_file_exists: bool = True,
+    project_file_exists: bool = True,
+) -> ConfigStatus:
     env_file = tmp_path / ".env"
     if env_file_exists:
         env_file.write_text("")
     primary_project_file = tmp_path / ".guildbotics/config/team/project.yml"
     primary_project_file.parent.mkdir(parents=True, exist_ok=True)
-    primary_project_file.write_text("language: en\n")
+    if project_file_exists:
+        primary_project_file.write_text("language: en\n")
     home_project_file = tmp_path / "home/.guildbotics/config/team/project.yml"
     return ConfigStatus(
         cwd=tmp_path,
@@ -28,6 +43,35 @@ def _config_status(tmp_path: Path, *, env_file_exists: bool = True) -> ConfigSta
     )
 
 
+def _isolated_config_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point config resolution at the workspace and neutralize ambient env."""
+    monkeypatch.setenv("GUILDBOTICS_CONFIG_DIR", str(tmp_path / ".guildbotics/config"))
+    monkeypatch.setenv("PATH", "")
+    for key in PROVIDER_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+
+def _write_model_mapping(tmp_path: Path, default: str) -> None:
+    mapping = tmp_path / ".guildbotics/config/intelligences/model_mapping.yml"
+    mapping.parent.mkdir(parents=True, exist_ok=True)
+    mapping.write_text(f"default: {default}\n")
+
+
+def _write_cli_agent(tmp_path: Path, mapping_default: str, script: str) -> None:
+    cli_mapping = tmp_path / ".guildbotics/config/intelligences/cli_agent_mapping.yml"
+    cli_mapping.parent.mkdir(parents=True, exist_ok=True)
+    cli_mapping.write_text(f"default: {mapping_default}\n")
+    cli_agent = (
+        tmp_path / ".guildbotics/config/intelligences/cli_agents" / mapping_default
+    )
+    cli_agent.parent.mkdir(parents=True, exist_ok=True)
+    cli_agent.write_text(f"script: {script}\n")
+
+
+def _checks_by_code(response) -> dict:
+    return {check.code: check for check in response.checks}
+
+
 def test_verify_reports_missing_active_member(tmp_path: Path) -> None:
     config = _config_status(tmp_path)
     team = Team(project=Project(name="demo"), members=[])
@@ -37,6 +81,357 @@ def test_verify_reports_missing_active_member(tmp_path: Path) -> None:
     assert not response.ok
     assert response.active_members == []
     assert "active_members" in {check.code for check in response.errors}
+
+
+def test_verify_reports_missing_project_file(tmp_path: Path) -> None:
+    config = _config_status(tmp_path, project_file_exists=False)
+    team = Team(project=Project(name="demo"), members=[])
+
+    response = VerifyService().verify(config=config, team=team)
+
+    checks = _checks_by_code(response)
+    assert checks["config_project_file"].status == "error"
+    assert not response.ok
+
+
+def test_verify_reports_missing_env_file_as_warning(tmp_path: Path) -> None:
+    config = _config_status(tmp_path, env_file_exists=False)
+    team = Team(
+        project=Project(name="demo"),
+        members=[Person(person_id="alice", name="Alice", is_active=True)],
+    )
+
+    response = VerifyService().verify(config=config, team=team)
+
+    checks = _checks_by_code(response)
+    assert checks["env_file"].status == "warning"
+    assert "env_file" in {check.code for check in response.warnings}
+
+
+def test_verify_team_load_error(tmp_path: Path) -> None:
+    config = _config_status(tmp_path)
+
+    response = VerifyService().verify(
+        config=config, team=None, team_error=ValueError("broken team")
+    )
+
+    checks = _checks_by_code(response)
+    assert checks["team_load"].status == "error"
+    assert checks["team_load"].message == "broken team"
+    assert checks["team_load"].context == {"error_type": "ValueError"}
+    assert not response.ok
+
+
+def test_verify_team_load_none_without_error(tmp_path: Path) -> None:
+    config = _config_status(tmp_path)
+
+    response = VerifyService().verify(config=config, team=None)
+
+    checks = _checks_by_code(response)
+    assert checks["team_load"].status == "error"
+    assert checks["team_load"].message == "Team config could not be loaded."
+    # LLM / cli / github checks are skipped when there is no team.
+    assert "llm_api_key" not in checks
+
+
+def test_verify_multiple_active_members(tmp_path: Path) -> None:
+    config = _config_status(tmp_path)
+    team = Team(
+        project=Project(name="demo"),
+        members=[
+            Person(person_id="alice", name="Alice", is_active=True),
+            Person(person_id="bob", name="Bob", is_active=True),
+            Person(person_id="carol", name="Carol", is_active=False),
+        ],
+    )
+
+    response = VerifyService().verify(config=config, team=team)
+
+    checks = _checks_by_code(response)
+    assert response.active_members == ["alice", "bob"]
+    assert checks["active_members"].status == "ok"
+    assert checks["active_members"].context["active_members"] == ["alice", "bob"]
+
+
+@pytest.mark.parametrize(
+    ("default_model", "expected_key"),
+    [
+        ("models/openai/gpt-5-mini.yml", "OPENAI_API_KEY"),
+        ("models/gemini/gemini-2.5-pro.yml", "GOOGLE_API_KEY"),
+        ("models/google/gemini-2.5-pro.yml", "GOOGLE_API_KEY"),
+        ("models/anthropic/claude.yml", "ANTHROPIC_API_KEY"),
+        ("models/claude/claude.yml", "ANTHROPIC_API_KEY"),
+    ],
+)
+def test_verify_llm_provider_api_key_present(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    default_model: str,
+    expected_key: str,
+) -> None:
+    _isolated_config_env(tmp_path, monkeypatch)
+    config = _config_status(tmp_path)
+    config.env_file.write_text(f"{expected_key}=secret\n")
+    _write_model_mapping(tmp_path, default_model)
+    team = Team(
+        project=Project(name="demo"),
+        members=[Person(person_id="alice", name="Alice", is_active=True)],
+    )
+
+    response = VerifyService().verify(config=config, team=team)
+
+    check = _checks_by_code(response)["llm_api_key"]
+    assert check.status == "ok"
+    assert check.target == expected_key
+
+
+def test_verify_llm_provider_api_key_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _isolated_config_env(tmp_path, monkeypatch)
+    config = _config_status(tmp_path)
+    _write_model_mapping(tmp_path, "models/openai/gpt-5-mini.yml")
+    team = Team(
+        project=Project(name="demo"),
+        members=[Person(person_id="alice", name="Alice", is_active=True)],
+    )
+
+    response = VerifyService().verify(config=config, team=team)
+
+    check = _checks_by_code(response)["llm_api_key"]
+    assert check.status == "error"
+    assert check.target == "OPENAI_API_KEY"
+    assert check in response.errors
+
+
+def test_verify_llm_provider_unknown_is_warning(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _isolated_config_env(tmp_path, monkeypatch)
+    config = _config_status(tmp_path)
+    _write_model_mapping(tmp_path, "models/unknown/whatever.yml")
+    team = Team(
+        project=Project(name="demo"),
+        members=[Person(person_id="alice", name="Alice", is_active=True)],
+    )
+
+    response = VerifyService().verify(config=config, team=team)
+
+    check = _checks_by_code(response)["llm_provider"]
+    assert check.status == "warning"
+    assert check.context == {"provider": ""}
+
+
+def test_verify_cli_agent_executable_found(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _isolated_config_env(tmp_path, monkeypatch)
+    config = _config_status(tmp_path)
+    _write_model_mapping(tmp_path, "models/openai/gpt-5-mini.yml")
+    _write_cli_agent(tmp_path, "codex-cli.yml", "codex exec")
+    config.env_file.write_text("PATH=/custom/bin\n")
+
+    resolved: dict[str, object] = {}
+
+    def _resolve(executable: str, search_path: str | None) -> str:
+        resolved["executable"] = executable
+        resolved["search_path"] = search_path
+        return "/custom/bin/codex"
+
+    monkeypatch.setattr(verify_module, "resolve_cli_agent_path", _resolve)
+
+    team = Team(
+        project=Project(name="demo"),
+        members=[Person(person_id="alice", name="Alice", is_active=True)],
+    )
+
+    response = VerifyService().verify(config=config, team=team)
+
+    check = _checks_by_code(response)["cli_agent_executable"]
+    assert check.status == "ok"
+    assert check.target == "codex"
+    assert check.context["path"] == "/custom/bin/codex"
+    # The .env PATH value is passed through to the resolver.
+    assert resolved == {"executable": "codex", "search_path": "/custom/bin"}
+
+
+def test_verify_cli_agent_executable_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _isolated_config_env(tmp_path, monkeypatch)
+    config = _config_status(tmp_path)
+    _write_model_mapping(tmp_path, "models/openai/gpt-5-mini.yml")
+    _write_cli_agent(tmp_path, "codex-cli.yml", "codex exec")
+
+    monkeypatch.setattr(verify_module, "resolve_cli_agent_path", lambda *_a, **_k: "")
+
+    team = Team(
+        project=Project(name="demo"),
+        members=[Person(person_id="alice", name="Alice", is_active=True)],
+    )
+
+    response = VerifyService().verify(config=config, team=team)
+
+    check = _checks_by_code(response)["cli_agent_executable"]
+    assert check.status == "error"
+    assert check.target == "codex"
+    assert check in response.errors
+
+
+def test_verify_cli_agent_mapping_missing_warns(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _isolated_config_env(tmp_path, monkeypatch)
+    config = _config_status(tmp_path)
+    _write_model_mapping(tmp_path, "models/openai/gpt-5-mini.yml")
+    # Mapping points to a definition whose script names no known executable.
+    _write_cli_agent(tmp_path, "ghost-cli.yml", "python run.py")
+
+    team = Team(
+        project=Project(name="demo"),
+        members=[Person(person_id="alice", name="Alice", is_active=True)],
+    )
+
+    response = VerifyService().verify(config=config, team=team)
+
+    checks = _checks_by_code(response)
+    assert "cli_agent_executable" not in checks
+    assert checks["cli_agent_mapping"].status == "warning"
+
+
+def test_verify_github_disabled_skips_credentials(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _isolated_config_env(tmp_path, monkeypatch)
+    config = _config_status(tmp_path)
+    _write_model_mapping(tmp_path, "models/openai/gpt-5-mini.yml")
+    _write_cli_agent(tmp_path, "codex-cli.yml", "codex exec")
+    team = Team(
+        project=Project(name="demo"),
+        members=[
+            Person(
+                person_id="alice",
+                name="Alice",
+                is_active=True,
+                person_type=GitHubAppAuth.MACHINE_USER,
+            )
+        ],
+    )
+
+    response = VerifyService().verify(config=config, team=team)
+
+    assert "github_credential" not in _checks_by_code(response)
+
+
+@pytest.mark.parametrize(
+    ("person_type", "env_keys"),
+    [
+        (
+            GitHubAppAuth.GITHUB_APPS,
+            (
+                "ALICE_GITHUB_INSTALLATION_ID",
+                "ALICE_GITHUB_APP_ID",
+                "ALICE_GITHUB_PRIVATE_KEY_PATH",
+            ),
+        ),
+        (GitHubAppAuth.MACHINE_USER, ("ALICE_GITHUB_ACCESS_TOKEN",)),
+        (GitHubAppAuth.PROXY_AGENT, ("ALICE_GITHUB_ACCESS_TOKEN",)),
+    ],
+)
+def test_verify_github_credentials_present(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    person_type: str,
+    env_keys: tuple[str, ...],
+) -> None:
+    _isolated_config_env(tmp_path, monkeypatch)
+    config = _config_status(tmp_path)
+    config.env_file.write_text("\n".join(f"{key}=value" for key in env_keys) + "\n")
+    _write_model_mapping(tmp_path, "models/openai/gpt-5-mini.yml")
+    _write_cli_agent(tmp_path, "codex-cli.yml", "codex exec")
+    team = Team(
+        project=Project(name="demo", services={"ticket_manager": {"name": "GitHub"}}),
+        members=[
+            Person(
+                person_id="alice",
+                name="Alice",
+                is_active=True,
+                person_type=person_type,
+            )
+        ],
+    )
+
+    response = VerifyService().verify(config=config, team=team)
+
+    github_checks = [
+        check for check in response.checks if check.code == "github_credential"
+    ]
+    assert len(github_checks) == len(env_keys)
+    assert all(check.status == "ok" for check in github_checks)
+    assert {check.target for check in github_checks} == set(env_keys)
+
+
+@pytest.mark.parametrize(
+    ("person_type", "env_key"),
+    [
+        (GitHubAppAuth.GITHUB_APPS, "ALICE_GITHUB_APP_ID"),
+        (GitHubAppAuth.MACHINE_USER, "ALICE_GITHUB_ACCESS_TOKEN"),
+        (GitHubAppAuth.PROXY_AGENT, "ALICE_GITHUB_ACCESS_TOKEN"),
+    ],
+)
+def test_verify_github_credentials_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    person_type: str,
+    env_key: str,
+) -> None:
+    _isolated_config_env(tmp_path, monkeypatch)
+    config = _config_status(tmp_path)
+    _write_model_mapping(tmp_path, "models/openai/gpt-5-mini.yml")
+    _write_cli_agent(tmp_path, "codex-cli.yml", "codex exec")
+    team = Team(
+        project=Project(name="demo", services={"ticket_manager": {"name": "GitHub"}}),
+        members=[
+            Person(
+                person_id="alice",
+                name="Alice",
+                is_active=True,
+                person_type=person_type,
+            )
+        ],
+    )
+
+    response = VerifyService().verify(config=config, team=team)
+
+    missing = {
+        check.target for check in response.errors if check.code == "github_credential"
+    }
+    assert env_key in missing
+    assert not response.ok
+
+
+def test_verify_human_member_has_no_github_keys(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _isolated_config_env(tmp_path, monkeypatch)
+    config = _config_status(tmp_path)
+    _write_model_mapping(tmp_path, "models/openai/gpt-5-mini.yml")
+    _write_cli_agent(tmp_path, "codex-cli.yml", "codex exec")
+    team = Team(
+        project=Project(name="demo", services={"ticket_manager": {"name": "GitHub"}}),
+        members=[
+            Person(
+                person_id="alice",
+                name="Alice",
+                is_active=True,
+                person_type=GitHubAppAuth.HUMAN,
+            )
+        ],
+    )
+
+    response = VerifyService().verify(config=config, team=team)
+
+    assert "github_credential" not in _checks_by_code(response)
 
 
 def test_verify_checks_env_keys_and_github_credentials(

--- a/tests/guildbotics/app_api/test_verify.py
+++ b/tests/guildbotics/app_api/test_verify.py
@@ -445,6 +445,7 @@ def test_verify_checks_env_keys_and_github_credentials(
             [
                 "OPENAI_API_KEY=openai-key",
                 "ALICE_GITHUB_ACCESS_TOKEN=github-token",
+                "PATH=",
             ]
         )
     )

--- a/tests/guildbotics/drivers/test_command_chain.py
+++ b/tests/guildbotics/drivers/test_command_chain.py
@@ -1,0 +1,516 @@
+"""End-to-end unit tests for the command runner and command specs.
+
+These tests exercise the real ``CommandRunner`` / ``CommandSpecFactory`` /
+``Context`` collaboration using on-disk command files under ``tmp_path`` and
+``GUILDBOTICS_CONFIG_DIR``. They focus on behaviours that the existing
+``test_command_runner.py`` (which uses doubles) does not cover:
+
+- ``Context.pipe`` and ``shared_state`` update ordering across a multi-command
+  chain (children run before the parent; pipe reflects the last command).
+- parent-command behaviour when a child command fails (error propagates,
+  parent body never executes).
+- YAML command ``commands:`` being empty / invalid / nested.
+- Markdown command frontmatter options (``brain: none`` disables the brain and
+  renders placeholders) and nested ``commands:``.
+- Python command async vs sync ``main`` and context/positional/keyword binding.
+- Shell command cwd / env / stderr / non-zero exit.
+- inline ``print`` / ``to_html`` / ``to_pdf`` behaviour within a chain.
+- person-specific command vs common command fallback.
+
+External I/O is kept hermetic: shell commands use trivial real ``bash``
+snippets, and ``to_pdf`` stubs ``weasyprint.HTML`` so the test does not depend
+on native libraries.
+"""
+
+from __future__ import annotations
+
+import base64
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from guildbotics.commands.errors import (
+    CommandError,
+    PersonNotFoundError,
+    PersonSelectionRequiredError,
+)
+from guildbotics.drivers.command_runner import CommandRunner, run_command
+from guildbotics.entities.team import Person, Project, Team
+from guildbotics.runtime.context import Context
+from tests.guildbotics.runtime.test_context import (
+    DummyBrainFactory,
+    DummyIntegrationFactory,
+    DummyLoaderFactory,
+)
+
+# --- Fixtures / helpers ----------------------------------------------------
+
+
+def _make_team(members: list[Person] | None = None) -> Team:
+    if members is None:
+        members = [Person(person_id="alice", name="Alice", is_active=True)]
+    return Team(project=Project(name="demo", language="en"), members=members)
+
+
+def _make_context(message: str = "", team: Team | None = None) -> Context:
+    team = team or _make_team()
+    loader_factory = DummyLoaderFactory(team)
+    base = Context.get_default(
+        loader_factory, DummyIntegrationFactory(), DummyBrainFactory(), message
+    )
+    active = next((m for m in team.members if m.is_active), team.members[0])
+    return base.clone_for(active)
+
+
+@pytest.fixture
+def config_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Provide an isolated primary config dir with a commands/ subdir."""
+    root = tmp_path / "config"
+    (root / "commands").mkdir(parents=True)
+    monkeypatch.setenv("GUILDBOTICS_CONFIG_DIR", str(root))
+    return root
+
+
+async def _run_main(
+    config_dir: Path, name: str, args: list[str] | None = None, message: str = ""
+) -> Context:
+    """Run a named command resolved from config_dir and return its context."""
+    ctx = _make_context(message)
+    runner = CommandRunner(ctx, name, args or [], cwd=config_dir)
+    await runner.run()
+    return ctx
+
+
+# --- pipe / shared_state ordering across a chain ---------------------------
+
+
+@pytest.mark.asyncio
+async def test_chain_runs_children_before_parent_and_orders_pipe(config_dir: Path):
+    """Children run first; pipe ends with the parent output; shared_state keeps all."""
+    commands = config_dir / "commands"
+    # Parent yaml referencing two python children, then a print parent step.
+    (commands / "first.py").write_text(
+        "def main():\n    return 'first-output'\n", encoding="utf-8"
+    )
+    (commands / "second.py").write_text(
+        "def main():\n    return 'second-output'\n", encoding="utf-8"
+    )
+    (commands / "chain.md").write_text(
+        "---\n"
+        "brain: none\n"
+        "commands:\n"
+        "  - first\n"
+        "  - second\n"
+        "---\n"
+        "parent saw: {first} & {second}\n",
+        encoding="utf-8",
+    )
+
+    ctx = await _run_main(config_dir, "chain")
+
+    # Children executed before parent and recorded under their own output keys.
+    assert ctx.shared_state["first"] == "first-output"
+    assert ctx.shared_state["second"] == "second-output"
+    # Parent (markdown brain=none) rendered placeholders from shared_state and
+    # is the last to write the pipe.
+    assert ctx.shared_state["chain"] == "parent saw: first-output & second-output"
+    assert ctx.pipe == "parent saw: first-output & second-output"
+
+
+@pytest.mark.asyncio
+async def test_pipe_flows_as_stdin_into_each_command(config_dir: Path):
+    """pipe is fed as stdin/message; each command can transform and forward it."""
+    commands = config_dir / "commands"
+    # A shell child uppercases stdin, the parent shell appends a marker.
+    (commands / "upper.sh").write_text(
+        "#!/usr/bin/env bash\ntr '[:lower:]' '[:upper:]'\n", encoding="utf-8"
+    )
+    (commands / "pipe_parent.yml").write_text(
+        "commands:\n  - upper\n",
+        encoding="utf-8",
+    )
+
+    ctx = await _run_main(config_dir, "pipe_parent", message="hello")
+
+    # Child shell read the initial pipe ("hello") from stdin and uppercased it.
+    assert ctx.shared_state["upper"].strip() == "HELLO"
+    # Yaml parent returns None, so the pipe stays at the child's output.
+    assert ctx.pipe.strip() == "HELLO"
+
+
+# --- child command failure -> parent never runs ----------------------------
+
+
+@pytest.mark.asyncio
+async def test_child_failure_propagates_and_parent_not_executed(config_dir: Path):
+    """A failing child raises CommandError and the parent body never runs."""
+    commands = config_dir / "commands"
+    (commands / "boom.py").write_text(
+        "def main():\n    raise ValueError('child exploded')\n", encoding="utf-8"
+    )
+    (commands / "outer.md").write_text(
+        "---\nbrain: none\ncommands:\n  - boom\n---\nPARENT-MARKER\n",
+        encoding="utf-8",
+    )
+
+    ctx = _make_context("seed")
+    runner = CommandRunner(ctx, "outer", [], cwd=config_dir)
+
+    with pytest.raises(ValueError, match="child exploded"):
+        await runner.run()
+
+    # Parent markdown body never produced output; pipe untouched by the parent.
+    assert "outer" not in ctx.shared_state
+    assert ctx.pipe == "seed"
+
+
+# --- YAML command commands: empty / invalid / nested -----------------------
+
+
+@pytest.mark.asyncio
+async def test_yaml_empty_commands_is_noop(config_dir: Path):
+    """An empty commands: list produces no children and leaves pipe unchanged."""
+    commands = config_dir / "commands"
+    (commands / "empty.yml").write_text("commands: []\n", encoding="utf-8")
+
+    ctx = await _run_main(config_dir, "empty", message="unchanged")
+
+    assert ctx.shared_state == {}
+    assert ctx.pipe == "unchanged"
+
+
+@pytest.mark.asyncio
+async def test_yaml_invalid_command_entry_raises(config_dir: Path):
+    """A non-string / non-mapping command entry raises a CommandError."""
+    commands = config_dir / "commands"
+    (commands / "bad.yml").write_text("commands:\n  - [1, 2, 3]\n", encoding="utf-8")
+
+    ctx = _make_context()
+    runner = CommandRunner(ctx, "bad", [], cwd=config_dir)
+
+    with pytest.raises(CommandError, match="must be a mapping or string"):
+        await runner.run()
+
+
+@pytest.mark.asyncio
+async def test_yaml_nested_commands_execute_depth_first(config_dir: Path):
+    """Nested yaml commands run their grandchildren before children."""
+    commands = config_dir / "commands"
+    (commands / "leaf.py").write_text(
+        "def main():\n    return 'leaf'\n", encoding="utf-8"
+    )
+    (commands / "inner.yml").write_text("commands:\n  - leaf\n", encoding="utf-8")
+    (commands / "root.yml").write_text("commands:\n  - inner\n", encoding="utf-8")
+
+    ctx = await _run_main(config_dir, "root", message="x")
+
+    # Grandchild python ran and recorded output; yaml wrappers return None.
+    assert ctx.shared_state["leaf"] == "leaf"
+    assert ctx.pipe == "leaf"
+
+
+# --- Markdown frontmatter options ------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_markdown_brain_disabled_renders_placeholders(config_dir: Path):
+    """brain: none renders the body with default placeholder substitution."""
+    commands = config_dir / "commands"
+    (commands / "render.md").write_text(
+        "---\nbrain: none\n---\nName is $name\n", encoding="utf-8"
+    )
+
+    ctx = _make_context("ignored-pipe")
+    ctx.shared_state["name"] = "Ada"
+    runner = CommandRunner(ctx, "render", [], cwd=config_dir)
+    await runner.run()
+
+    assert ctx.shared_state["render"] == "Name is Ada"
+    assert ctx.pipe == "Name is Ada"
+
+
+@pytest.mark.asyncio
+async def test_markdown_empty_body_returns_none(config_dir: Path):
+    """A markdown command with no body produces no outcome and no pipe change."""
+    commands = config_dir / "commands"
+    (commands / "blank.md").write_text("---\nbrain: none\n---\n", encoding="utf-8")
+
+    ctx = await _run_main(config_dir, "blank", message="keep")
+
+    assert "blank" not in ctx.shared_state
+    assert ctx.pipe == "keep"
+
+
+# --- Python command async vs sync, context/positional/keyword binding ------
+
+
+@pytest.mark.asyncio
+async def test_python_sync_main_returns_value(config_dir: Path):
+    commands = config_dir / "commands"
+    (commands / "sync_cmd.py").write_text(
+        "def main():\n    return 'sync-result'\n", encoding="utf-8"
+    )
+
+    ctx = await _run_main(config_dir, "sync_cmd")
+
+    assert ctx.shared_state["sync_cmd"] == "sync-result"
+    assert ctx.pipe == "sync-result"
+
+
+@pytest.mark.asyncio
+async def test_python_async_main_is_awaited(config_dir: Path):
+    commands = config_dir / "commands"
+    (commands / "async_cmd.py").write_text(
+        "import asyncio\n\n"
+        "async def main():\n"
+        "    await asyncio.sleep(0)\n"
+        "    return 'async-result'\n",
+        encoding="utf-8",
+    )
+
+    ctx = await _run_main(config_dir, "async_cmd")
+
+    # An awaited coroutine result, not a coroutine object.
+    assert ctx.shared_state["async_cmd"] == "async-result"
+    assert ctx.pipe == "async-result"
+
+
+@pytest.mark.asyncio
+async def test_python_main_receives_context_positional_and_keyword(config_dir: Path):
+    commands = config_dir / "commands"
+    (commands / "bound.py").write_text(
+        "def main(context, first, second, *, flag):\n"
+        "    return f'{context.person.person_id}:{first}:{second}:{flag}'\n",
+        encoding="utf-8",
+    )
+
+    ctx = await _run_main(
+        config_dir, "bound", args=["pos1", "pos2", "flag=on"], message=""
+    )
+
+    assert ctx.shared_state["bound"] == "alice:pos1:pos2:on"
+
+
+# --- Shell command cwd / env / stderr / non-zero exit ----------------------
+
+
+@pytest.mark.asyncio
+async def test_shell_runs_in_spec_cwd(config_dir: Path, tmp_path: Path):
+    work = tmp_path / "work"
+    work.mkdir()
+    commands = config_dir / "commands"
+    (commands / "pwd.yml").write_text(
+        f"commands:\n  - command: print_pwd\n    cwd: {work}\n", encoding="utf-8"
+    )
+    (commands / "print_pwd.sh").write_text(
+        "#!/usr/bin/env bash\npwd\n", encoding="utf-8"
+    )
+
+    ctx = await _run_main(config_dir, "pwd")
+
+    assert ctx.shared_state["print_pwd"].strip() == str(work.resolve())
+
+
+@pytest.mark.asyncio
+async def test_shell_receives_params_as_env(config_dir: Path):
+    commands = config_dir / "commands"
+    (commands / "env_echo.sh").write_text(
+        '#!/usr/bin/env bash\necho "$GREETING"\n', encoding="utf-8"
+    )
+    (commands / "env_parent.yml").write_text(
+        "commands:\n  - command: env_echo\n    params:\n      GREETING: from-env\n",
+        encoding="utf-8",
+    )
+
+    ctx = await _run_main(config_dir, "env_parent")
+
+    assert ctx.shared_state["env_echo"].strip() == "from-env"
+
+
+@pytest.mark.asyncio
+async def test_shell_nonzero_exit_includes_stderr(config_dir: Path):
+    commands = config_dir / "commands"
+    (commands / "fail.sh").write_text(
+        "#!/usr/bin/env bash\necho 'oops on stderr' >&2\nexit 3\n", encoding="utf-8"
+    )
+
+    ctx = _make_context()
+    runner = CommandRunner(ctx, "fail", [], cwd=config_dir)
+
+    with pytest.raises(CommandError) as excinfo:
+        await runner.run()
+
+    message = str(excinfo.value)
+    assert "exit code 3" in message
+    assert "oops on stderr" in message
+
+
+# --- inline print / to_html / to_pdf inside a chain ------------------------
+
+
+@pytest.mark.asyncio
+async def test_inline_print_renders_with_jinja2_in_chain(config_dir: Path):
+    """An inline print step renders shared_state via jinja2 and updates pipe."""
+    commands = config_dir / "commands"
+    (commands / "seed.py").write_text(
+        "def main():\n    return 'world'\n", encoding="utf-8"
+    )
+    (commands / "printer.yml").write_text(
+        "commands:\n  - seed\n  - name: greeting\n    print: 'Hello {{ seed }}!'\n",
+        encoding="utf-8",
+    )
+
+    ctx = await _run_main(config_dir, "printer")
+
+    assert ctx.shared_state["seed"] == "world"
+    assert ctx.shared_state["greeting"] == "Hello world!"
+    # The inline print is the final child, so it owns the pipe.
+    assert ctx.pipe == "Hello world!"
+
+
+@pytest.mark.asyncio
+async def test_inline_to_html_in_chain(config_dir: Path):
+    commands = config_dir / "commands"
+    (commands / "body.py").write_text(
+        "def main():\n    return '# Heading'\n", encoding="utf-8"
+    )
+    (commands / "html_parent.yml").write_text(
+        "commands:\n  - body\n  - name: rendered\n    to_html: {}\n",
+        encoding="utf-8",
+    )
+
+    ctx = await _run_main(config_dir, "html_parent")
+
+    rendered = ctx.shared_state["rendered"]
+    assert "<h1>Heading</h1>" in rendered
+    assert ctx.pipe == rendered
+
+
+@pytest.mark.asyncio
+async def test_inline_to_pdf_in_chain(config_dir: Path, monkeypatch):
+    """to_pdf within a chain produces PDF bytes; weasyprint is stubbed."""
+    fake_weasyprint = _install_fake_weasyprint(monkeypatch)
+
+    commands = config_dir / "commands"
+    (commands / "doc.py").write_text(
+        "def main():\n    return '# Title'\n", encoding="utf-8"
+    )
+    (commands / "pdf_parent.yml").write_text(
+        "commands:\n  - doc\n  - name: pdf\n    to_pdf: {}\n",
+        encoding="utf-8",
+    )
+
+    ctx = await _run_main(config_dir, "pdf_parent")
+
+    # result is the raw PDF bytes; pipe (text_output) is the base64 encoding.
+    assert ctx.shared_state["pdf"] == b"%PDF-FAKE"
+    assert ctx.pipe == base64.b64encode(b"%PDF-FAKE").decode("ascii")
+    # The HTML passed to weasyprint contained the rendered markdown heading.
+    assert "<h1>Title</h1>" in fake_weasyprint["last_html"]
+
+
+def _install_fake_weasyprint(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Install a fake weasyprint module so to_pdf needs no native libs."""
+    import types
+
+    captured: dict[str, Any] = {}
+
+    class _FakeHTML:
+        def __init__(self, string: str = "", base_url: str | None = None) -> None:
+            captured["last_html"] = string
+
+        def write_pdf(self) -> bytes:
+            return b"%PDF-FAKE"
+
+    module = types.ModuleType("weasyprint")
+    module.HTML = _FakeHTML  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "weasyprint", module)
+    return captured
+
+
+# --- person-specific command vs common command fallback --------------------
+
+
+@pytest.mark.asyncio
+async def test_person_specific_command_overrides_common(config_dir: Path):
+    """A member-scoped command takes precedence over the common command."""
+    commands = config_dir / "commands"
+    member_commands = config_dir / "team" / "members" / "alice" / "commands"
+    member_commands.mkdir(parents=True)
+
+    (commands / "greet.py").write_text(
+        "def main():\n    return 'common-greeting'\n", encoding="utf-8"
+    )
+    (member_commands / "greet.py").write_text(
+        "def main():\n    return 'alice-greeting'\n", encoding="utf-8"
+    )
+
+    ctx = await _run_main(config_dir, "greet")
+
+    assert ctx.shared_state["greet"] == "alice-greeting"
+
+
+@pytest.mark.asyncio
+async def test_falls_back_to_common_command_when_no_person_specific(config_dir: Path):
+    """Without a member-scoped file, the common command resolves."""
+    commands = config_dir / "commands"
+    (commands / "greet.py").write_text(
+        "def main():\n    return 'common-greeting'\n", encoding="utf-8"
+    )
+
+    ctx = await _run_main(config_dir, "greet")
+
+    assert ctx.shared_state["greet"] == "common-greeting"
+
+
+# --- run_command person resolution -----------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_command_requires_person_when_ambiguous(config_dir: Path):
+    """With multiple active members and no identifier, selection is required."""
+    commands = config_dir / "commands"
+    (commands / "noop.py").write_text("def main():\n    return 'x'\n", encoding="utf-8")
+    team = _make_team(
+        [
+            Person(person_id="alice", name="Alice Anderson", is_active=True),
+            Person(person_id="bob", name="bob", is_active=True),
+        ]
+    )
+    ctx = _make_context(team=team)
+
+    with pytest.raises(PersonSelectionRequiredError) as excinfo:
+        await run_command(ctx, "noop", [], person_identifier=None, cwd=config_dir)
+
+    # Sorted labels: a distinct display name gets a "id (name)" label, while a
+    # name matching the id (case-insensitively) is shown as the bare id.
+    assert excinfo.value.available == ["alice (Alice Anderson)", "bob"]
+
+
+@pytest.mark.asyncio
+async def test_run_command_unknown_person_raises(config_dir: Path):
+    commands = config_dir / "commands"
+    (commands / "noop.py").write_text("def main():\n    return 'x'\n", encoding="utf-8")
+    ctx = _make_context()
+
+    with pytest.raises(PersonNotFoundError) as excinfo:
+        await run_command(ctx, "noop", [], person_identifier="ghost", cwd=config_dir)
+
+    assert excinfo.value.identifier == "ghost"
+
+
+@pytest.mark.asyncio
+async def test_run_command_selects_single_active_member(config_dir: Path):
+    commands = config_dir / "commands"
+    (commands / "whoami.py").write_text(
+        "def main(context):\n    return context.person.person_id\n", encoding="utf-8"
+    )
+    ctx = _make_context()
+
+    result = await run_command(
+        ctx, "whoami", [], person_identifier=None, cwd=config_dir
+    )
+
+    assert result == "alice"

--- a/tests/guildbotics/editions/simple/test_setup_service_config_write.py
+++ b/tests/guildbotics/editions/simple/test_setup_service_config_write.py
@@ -1,0 +1,595 @@
+"""Config-write coverage for the simple setup service (session S17).
+
+These tests extend ``test_setup_service.py`` and focus on the file/env/YAML
+write behaviours called out in ``docs/test_gap_analysis.ja.md`` under
+"### P1: setup service / config write" that the existing suite did not yet
+exercise:
+
+- project init file set across workspace / home / custom config locations
+- ``.env`` skip / append / overwrite operations for ``write_project``
+- secret blank-update must not clear an existing secret (same-id update)
+- GitHub disabled -> enabled -> disabled project diff
+- repo access https / ssh round trip
+- member add / update / delete env-key add / update / remove
+- member-id rename moves directory + env keys + slack channel mapping
+- ``task_schedules`` / ``routine_commands`` YAML round trip
+- character / relationships / speaking_style round trip
+
+All filesystem writes use ``tmp_path`` so the real home directory is never
+touched.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from guildbotics.editions.simple.setup_service import (
+    PersonSetupInput,
+    PersonUpdateInput,
+    ProjectSetupInput,
+    ProjectUpdateInput,
+    SimplePersonSetupService,
+    SimpleProjectSetupService,
+)
+from guildbotics.utils.fileio import load_yaml_file
+
+# Relative config-dir layout produced by ``write_project`` independent of the
+# absolute config location (workspace / home / custom).
+PROJECT_RELATIVE_FILES = {
+    "team/project.yml",
+    "intelligences/model_mapping.yml",
+    "intelligences/cli_agent_mapping.yml",
+    "commands/translate.md",
+    "commands/summarize.md",
+    "commands/context-info.md",
+    "commands/get-time-of-day.yml",
+}
+
+
+def _project_input(
+    config_dir: Path, env_file_path: Path, **overrides
+) -> ProjectSetupInput:
+    payload: dict = {
+        "config_dir": config_dir,
+        "env_file_path": env_file_path,
+        "env_file_option": "overwrite",
+        "language": "en",
+        "llm_api_type": "openai",
+        "cli_agent": "codex",
+        "openai_api_key": "test-openai-key",
+    }
+    payload.update(overrides)
+    return ProjectSetupInput(**payload)
+
+
+def _github_project_input(
+    config_dir: Path, env_file_path: Path, **overrides
+) -> ProjectSetupInput:
+    return _project_input(
+        config_dir,
+        env_file_path,
+        repository_name="GuildBotics",
+        owner="GuildBotics",
+        project_id="1",
+        github_project_url="https://github.com/orgs/GuildBotics/projects/1",
+        **overrides,
+    )
+
+
+def _person_input(
+    config_dir: Path, env_file_path: Path, **overrides
+) -> PersonSetupInput:
+    payload: dict = {
+        "config_dir": config_dir,
+        "env_file_path": env_file_path,
+        "append_env_file": False,
+        "person_type": "machine_user",
+        "person_id": "alice",
+        "person_name": "Alice",
+        "is_active": True,
+        "github_username": "alice",
+        "git_email": "1+alice@users.noreply.github.com",
+        "roles": ["architect"],
+        "speaking_style": "style-a",
+    }
+    payload.update(overrides)
+    return PersonSetupInput(**payload)
+
+
+def _env_dict(env_file_path: Path) -> dict[str, str]:
+    text = env_file_path.read_text()
+    values: dict[str, str] = {}
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        key, _, value = line.partition("=")
+        values[key] = value
+    return values
+
+
+# --------------------------------------------------------------------------- #
+# project init: file set per config location (workspace / home / custom)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "location",
+    [".guildbotics/config", "home_config", "custom/place/config"],
+    ids=["workspace", "home", "custom"],
+)
+def test_write_project_file_set_is_location_independent(
+    tmp_path: Path, location: str
+) -> None:
+    config_dir = tmp_path / location
+    env_file_path = tmp_path / location / ".env"
+
+    result = SimpleProjectSetupService().write_project(
+        _github_project_input(config_dir, env_file_path)
+    )
+
+    created_paths = {created_file.path for created_file in result.files}
+    for relative in PROJECT_RELATIVE_FILES:
+        expected = config_dir / relative
+        assert expected in created_paths
+        assert expected.exists()
+    # The cli_agent config bundle is copied alongside the mappings.
+    cli_agent_files = {
+        path for path in created_paths if "intelligences/cli_agents/" in str(path)
+    }
+    assert cli_agent_files
+    for path in cli_agent_files:
+        assert path.exists()
+    # The env file lives wherever the caller pointed it, even outside config_dir.
+    assert env_file_path in created_paths
+    assert env_file_path.exists()
+
+
+# --------------------------------------------------------------------------- #
+# .env skip / append / overwrite
+# --------------------------------------------------------------------------- #
+
+
+def test_write_project_env_skip_leaves_existing_file_untouched(
+    tmp_path: Path,
+) -> None:
+    config_dir = tmp_path / "config"
+    env_file_path = tmp_path / ".env"
+    env_file_path.write_text("PRESERVED=1")
+
+    result = SimpleProjectSetupService().write_project(
+        _github_project_input(config_dir, env_file_path, env_file_option="skip")
+    )
+
+    created_paths = {created_file.path for created_file in result.files}
+    assert env_file_path not in created_paths
+    assert env_file_path.read_text() == "PRESERVED=1"
+
+
+def test_write_project_env_overwrite_replaces_file(tmp_path: Path) -> None:
+    config_dir = tmp_path / "config"
+    env_file_path = tmp_path / ".env"
+    env_file_path.write_text("OLD=value\nOPENAI_API_KEY=stale")
+
+    result = SimpleProjectSetupService().write_project(
+        _github_project_input(config_dir, env_file_path, env_file_option="overwrite")
+    )
+
+    actions = {created_file.path: created_file.action for created_file in result.files}
+    assert actions[env_file_path] == "create"
+    text = env_file_path.read_text()
+    assert "OLD=value" not in text
+    assert "OPENAI_API_KEY=test-openai-key" in text
+
+
+def test_write_project_env_append_keeps_existing_lines(tmp_path: Path) -> None:
+    config_dir = tmp_path / "config"
+    env_file_path = tmp_path / ".env"
+    env_file_path.write_text("EXISTING=keep")
+
+    result = SimpleProjectSetupService().write_project(
+        _github_project_input(config_dir, env_file_path, env_file_option="append")
+    )
+
+    actions = {created_file.path: created_file.action for created_file in result.files}
+    assert actions[env_file_path] == "append"
+    text = env_file_path.read_text()
+    assert text.startswith("EXISTING=keep")
+    assert "OPENAI_API_KEY=test-openai-key" in text
+
+
+def test_project_input_append_requires_existing_env_file(tmp_path: Path) -> None:
+    config_dir = tmp_path / "config"
+    env_file_path = tmp_path / ".env"
+
+    with pytest.raises(ValueError, match="append requires an existing env file"):
+        _github_project_input(config_dir, env_file_path, env_file_option="append")
+
+
+# --------------------------------------------------------------------------- #
+# GitHub disabled -> enabled -> disabled diff + repo access https / ssh
+# --------------------------------------------------------------------------- #
+
+
+def _seed_project(config_dir: Path, env_file_path: Path) -> None:
+    SimpleProjectSetupService().write_project(_project_input(config_dir, env_file_path))
+
+
+def test_update_project_github_disabled_enabled_disabled_diff(
+    tmp_path: Path,
+) -> None:
+    config_dir = tmp_path / "config"
+    env_file_path = tmp_path / ".env"
+    _seed_project(config_dir, env_file_path)
+    service = SimpleProjectSetupService()
+    project_file = config_dir / "team/project.yml"
+
+    base = {
+        "config_dir": config_dir,
+        "env_file_path": env_file_path,
+        "language": "en",
+        "llm_api_type": "openai",
+        "cli_agent": "codex",
+    }
+
+    # Initially disabled: no GitHub services present.
+    service.update_project(ProjectUpdateInput(**base, github_enabled=False))
+    disabled = load_yaml_file(project_file)
+    assert "services" not in disabled
+    assert "repositories" not in disabled
+
+    # Enabled: ticket_manager + code_hosting_service + repositories added.
+    service.update_project(
+        ProjectUpdateInput(
+            **base,
+            github_enabled=True,
+            repository_name="GuildBotics",
+            owner="GuildBotics",
+            project_id="42",
+            github_project_url="https://github.com/orgs/GuildBotics/projects/42",
+        )
+    )
+    enabled = load_yaml_file(project_file)
+    services = enabled["services"]
+    assert services["ticket_manager"]["owner"] == "GuildBotics"
+    assert services["ticket_manager"]["project_id"] == "42"
+    assert services["ticket_manager"]["url"].endswith("/projects/42")
+    assert services["code_hosting_service"]["owner"] == "GuildBotics"
+    assert enabled["repositories"] == [{"name": "GuildBotics"}]
+
+    # Disabled again: GitHub services removed. NOTE: update_project only pops
+    # the ``services`` block, so a previously written ``repositories`` entry is
+    # intentionally left in place by the current implementation.
+    service.update_project(ProjectUpdateInput(**base, github_enabled=False))
+    re_disabled = load_yaml_file(project_file)
+    assert "services" not in re_disabled
+    assert re_disabled["repositories"] == [{"name": "GuildBotics"}]
+
+
+@pytest.mark.parametrize(
+    "repo_base_url",
+    ["https://github.com", "ssh://git@github.com"],
+)
+def test_update_project_round_trips_repo_access_scheme(
+    tmp_path: Path, repo_base_url: str
+) -> None:
+    config_dir = tmp_path / "config"
+    env_file_path = tmp_path / ".env"
+    _seed_project(config_dir, env_file_path)
+    service = SimpleProjectSetupService()
+
+    service.update_project(
+        ProjectUpdateInput(
+            config_dir=config_dir,
+            env_file_path=env_file_path,
+            language="en",
+            llm_api_type="openai",
+            cli_agent="codex",
+            github_enabled=True,
+            repository_name="GuildBotics",
+            owner="GuildBotics",
+            project_id="1",
+            github_project_url="https://github.com/orgs/GuildBotics/projects/1",
+            repo_base_url=repo_base_url,
+        )
+    )
+
+    stored = load_yaml_file(config_dir / "team/project.yml")
+    assert stored["services"]["code_hosting_service"]["repo_base_url"] == repo_base_url
+    snapshot = service.read_project_config(
+        config_dir=config_dir, env_file_path=env_file_path
+    )
+    assert snapshot.repo_base_url == repo_base_url
+    assert snapshot.github_enabled is True
+
+
+# --------------------------------------------------------------------------- #
+# secret blank-update must not clear an existing secret (same-id update)
+# --------------------------------------------------------------------------- #
+
+
+def test_update_person_blank_secret_keeps_existing_value_same_id(
+    tmp_path: Path,
+) -> None:
+    config_dir = tmp_path / "config"
+    env_file = tmp_path / ".env"
+    env_file.write_text("GLOBAL=keep")
+    service = SimplePersonSetupService()
+
+    service.write_person(
+        _person_input(
+            config_dir,
+            env_file,
+            append_env_file=True,
+            github_access_token="github-token",
+            slack_bot_token="xoxb-token",
+        )
+    )
+    assert _env_dict(env_file)["ALICE_GITHUB_ACCESS_TOKEN"] == "github-token"
+
+    # Update with blank secrets and an unrelated profile change.
+    service.update_person(
+        PersonUpdateInput(
+            config_dir=config_dir,
+            env_file_path=env_file,
+            original_person_id="alice",
+            append_env_file=False,
+            person_type="machine_user",
+            person_id="alice",
+            person_name="Alice Updated",
+            is_active=True,
+            github_username="alice",
+            git_email="1+alice@users.noreply.github.com",
+            roles=["reviewer"],
+            speaking_style="style-b",
+            github_access_token="",
+            slack_bot_token="",
+        )
+    )
+
+    env_values = _env_dict(env_file)
+    assert env_values["ALICE_GITHUB_ACCESS_TOKEN"] == "github-token"
+    assert env_values["ALICE_SLACK_BOT_TOKEN"] == "xoxb-token"
+
+
+# --------------------------------------------------------------------------- #
+# member add / update / delete: env secret key added / updated / removed
+# --------------------------------------------------------------------------- #
+
+
+def test_member_crud_adds_updates_and_removes_env_keys(tmp_path: Path) -> None:
+    config_dir = tmp_path / "config"
+    env_file = tmp_path / ".env"
+    env_file.write_text("GLOBAL=keep")
+    service = SimplePersonSetupService()
+
+    # add (append): env key created.
+    service.write_person(
+        _person_input(
+            config_dir,
+            env_file,
+            append_env_file=True,
+            github_access_token="token-v1",
+        )
+    )
+    assert _env_dict(env_file)["ALICE_GITHUB_ACCESS_TOKEN"] == "token-v1"
+
+    # update (same id): env key value replaced.
+    service.update_person(
+        PersonUpdateInput(
+            config_dir=config_dir,
+            env_file_path=env_file,
+            original_person_id="alice",
+            append_env_file=False,
+            person_type="machine_user",
+            person_id="alice",
+            person_name="Alice",
+            is_active=True,
+            github_username="alice",
+            git_email="1+alice@users.noreply.github.com",
+            roles=["architect"],
+            speaking_style="style-a",
+            github_access_token="token-v2",
+        )
+    )
+    env_values = _env_dict(env_file)
+    assert env_values["ALICE_GITHUB_ACCESS_TOKEN"] == "token-v2"
+    assert env_values["GLOBAL"] == "keep"
+
+    # delete: env key removed, unrelated key preserved.
+    service.delete_person(
+        config_dir=config_dir, person_id="alice", env_file_path=env_file
+    )
+    env_values = _env_dict(env_file)
+    assert "ALICE_GITHUB_ACCESS_TOKEN" not in env_values
+    assert env_values["GLOBAL"] == "keep"
+    assert not (config_dir / "team/members/alice/person.yml").exists()
+
+
+# --------------------------------------------------------------------------- #
+# member id rename: directory / env key / slack mapping are moved
+# --------------------------------------------------------------------------- #
+
+
+def test_member_rename_moves_directory_env_keys_and_slack_mapping(
+    tmp_path: Path,
+) -> None:
+    config_dir = tmp_path / "config"
+    env_file = tmp_path / ".env"
+    env_file.write_text("GLOBAL=keep")
+    service = SimplePersonSetupService()
+
+    service.write_person(
+        _person_input(
+            config_dir,
+            env_file,
+            append_env_file=True,
+            person_id="old-id",
+            github_username="old-id",
+            github_access_token="token-keep",
+            slack_bot_token="xoxb-keep",
+            slack_channels=["general"],
+        )
+    )
+    old_dir = config_dir / "team/members/old-id"
+    assert old_dir.exists()
+    old_person = load_yaml_file(old_dir / "person.yml")
+    assert old_person["message_channels"][0]["used_by"] == ["old-id"]
+
+    service.update_person(
+        PersonUpdateInput(
+            config_dir=config_dir,
+            env_file_path=env_file,
+            original_person_id="old-id",
+            append_env_file=False,
+            person_type="machine_user",
+            person_id="new-id",
+            person_name="Alice",
+            is_active=True,
+            github_username="new-id",
+            git_email="1+new-id@users.noreply.github.com",
+            roles=["architect"],
+            speaking_style="style-a",
+            # Blank secrets so we verify the rename PRESERVES existing values.
+            slack_channels=["general"],
+        )
+    )
+
+    new_dir = config_dir / "team/members/new-id"
+    assert new_dir.exists()
+    assert not old_dir.exists()
+
+    new_person = load_yaml_file(new_dir / "person.yml")
+    assert new_person["person_id"] == "new-id"
+    # Slack channel ownership mapping follows the new id.
+    assert new_person["message_channels"][0]["used_by"] == ["new-id"]
+
+    env_values = _env_dict(env_file)
+    assert "OLD_ID_GITHUB_ACCESS_TOKEN" not in env_values
+    assert "OLD_ID_SLACK_BOT_TOKEN" not in env_values
+    assert env_values["NEW_ID_GITHUB_ACCESS_TOKEN"] == "token-keep"
+    assert env_values["NEW_ID_SLACK_BOT_TOKEN"] == "xoxb-keep"
+
+
+def test_member_rename_into_existing_id_is_rejected(tmp_path: Path) -> None:
+    config_dir = tmp_path / "config"
+    env_file = tmp_path / ".env"
+    service = SimplePersonSetupService()
+
+    service.write_person(_person_input(config_dir, env_file, person_id="alice"))
+    service.write_person(
+        _person_input(
+            config_dir,
+            env_file,
+            person_id="bob",
+            github_username="bob",
+            git_email="2+bob@users.noreply.github.com",
+        )
+    )
+
+    with pytest.raises(Exception) as exc_info:
+        service.update_person(
+            PersonUpdateInput(
+                config_dir=config_dir,
+                env_file_path=env_file,
+                original_person_id="alice",
+                append_env_file=False,
+                person_type="machine_user",
+                person_id="bob",
+                person_name="Alice",
+                is_active=True,
+                github_username="alice",
+                git_email="1+alice@users.noreply.github.com",
+                roles=["architect"],
+                speaking_style="style-a",
+            )
+        )
+    assert getattr(exc_info.value, "code", "") == "person_id_conflict"
+    # Both members remain intact.
+    assert (config_dir / "team/members/alice/person.yml").exists()
+    assert (config_dir / "team/members/bob/person.yml").exists()
+
+
+# --------------------------------------------------------------------------- #
+# task_schedules / routine_commands YAML round trip
+# --------------------------------------------------------------------------- #
+
+
+def test_person_routines_and_schedules_yaml_round_trip(tmp_path: Path) -> None:
+    config_dir = tmp_path / "config"
+    env_file = tmp_path / ".env"
+    service = SimplePersonSetupService()
+
+    routine_commands = [
+        "workflows/ticket_driven_workflow",
+        "reports/daily_digest",
+    ]
+    task_schedules = [
+        {"command": "reports/morning region=jp", "schedules": ["0 9 * * 1-5"]},
+        {"command": "reports/evening", "schedules": ["0 18 * * *", "30 12 * * 6"]},
+    ]
+
+    service.write_person(
+        _person_input(
+            config_dir,
+            env_file,
+            routine_commands=routine_commands,
+            task_schedules=task_schedules,
+        )
+    )
+
+    # Raw YAML round trip.
+    stored = load_yaml_file(config_dir / "team/members/alice/person.yml")
+    assert stored["routine_commands"] == routine_commands
+    assert stored["task_schedules"] == task_schedules
+
+    # Snapshot round trip.
+    snapshot = service.read_person_config(
+        config_dir=config_dir, person_id="alice", env_file_path=env_file
+    )
+    assert snapshot.routine_commands == routine_commands
+    assert [s.model_dump() for s in snapshot.task_schedules] == task_schedules
+
+
+# --------------------------------------------------------------------------- #
+# character / relationships / speaking_style round trip
+# --------------------------------------------------------------------------- #
+
+
+def test_person_character_relationships_speaking_style_round_trip(
+    tmp_path: Path,
+) -> None:
+    config_dir = tmp_path / "config"
+    env_file = tmp_path / ".env"
+    service = SimplePersonSetupService()
+
+    character = {
+        "archetype": "strategic_pm",
+        "traits": ["organized", "calm"],
+        "conversation_preferences": {
+            "join_when": ["planning", "review"],
+            "avoid_when": ["off topic"],
+            "contribution_style": ["clarify", "summarize"],
+        },
+    }
+    service.write_person(
+        _person_input(
+            config_dir,
+            env_file,
+            speaking_style="Concise and direct.",
+            relationships="Reports to {pm}; mentors juniors.",
+            character=character,
+        )
+    )
+
+    stored = load_yaml_file(config_dir / "team/members/alice/person.yml")
+    assert stored["speaking_style"] == "Concise and direct."
+    assert stored["relationships"] == "Reports to {pm}; mentors juniors."
+    assert stored["profile"]["character"] == character
+
+    snapshot = service.read_person_config(
+        config_dir=config_dir, person_id="alice", env_file_path=env_file
+    )
+    assert snapshot.speaking_style == "Concise and direct."
+    assert snapshot.relationships == "Reports to {pm}; mentors juniors."
+    assert snapshot.character == character


### PR DESCRIPTION
## Summary

`docs/test_gap_analysis.ja.md` の P0/P1（一部 P2）に挙がっていたテストギャップを埋め、加えて Playwright による lean-but-real E2E スイートを新設し、関連ドキュメントを最新化する。Tauri ネイティブ smoke (S23) は実 OS / Tauri runtime が必要なため workflow_dispatch 想定で保留中。

- **Python backend / app_api**: app_api 全体（models / events / lifecycle / runtime config + commands / intelligences / verify / diagnostics / cli_agents / websocket / temp workspace integration / sidecar smoke）+ drivers の command chain + setup service の config write を網羅。`test_api.py` は 42 → 118 へ、`test_verify.py` は 2 → 25 へ拡張。app_api テスト合計 **327 passed**, `mypy guildbotics` clean。
- **Desktop frontend (Vitest unit/component)**: api client / backend / Bootstrap / Routing / Service Runtime / Commands / Setup / Members / Patrol / Intelligence / Diagnostics と App / SetupPage / trace / i18n の純粋関数、加えて実 `client.ts` を fetch/WS 境界モックに対して走らせる mock-server integration を追加。**251 passed**, typecheck / lint / duplicates / format clean。
- **Desktop E2E (Playwright, real browser + real Local API backend)**: 6 critical user journey（① 初回 setup → 実 `project.yml` 書き込み, ② member 追加 → 実永続, ③ scheduler / events start→running→stop, ④ command 実行 → `/events` ストリーム → history, ⑤ verify / scenario diagnostics 結果描画, ⑥ backend down → Bootstrap error → 復帰 → retry）を、5 スタックを完全分離した harness（temp workspace + temp HOME + 専用 port/token）で実行。journey ⑥ は control server で決定論化。chromium 実起動で 8 specs all green を 2 回連続確認、orphan プロセス無し。
- **Backend 変更**: GUI 環境（minimal PATH）でも CLI agent 実体を発見できるよう `get_cli_agent_search_path()` / `resolve_cli_agent_path()` を新設し、`runtime.detect_cli_agents` / `verify` / `diagnostics` / `intelligences` / `brains/cli_agent` の PATH 解決を一本化。
- **ドキュメント**: `docs/test_gap_analysis.ja.md` の E2E セクションを再設計（Playwright 前提の lean-but-real journey 群へ）、AGENTS.md と desktop/README.md にテスト/E2E 実行手順を反映、CONTRIBUTING（en/ja）を AGENTS.md / desktop/README.md / ci.yml を正典とする DRY 構成に再整理し stale（Python 3.11+ / Black / 存在しない main.py・tests/it/ 等）を修正。

## Commit breakdown

1. `feat(cli-agent)` — GUI 環境向け CLI agent PATH 解決
2. `chore(scripts)` — desktop 用 dev/build スクリプト
3. `test(backend)` — Python backend / app_api テスト拡充
4. `test(desktop)` — Vitest unit/component カバレッジ拡充（純粋関数 export 含む）
5. `test(e2e)` — Playwright lean-but-real journey スイート
6. `docs` — テスト戦略 / E2E / CONTRIBUTING 整合

## 安全性 / hermetic 性

- すべての Python テストは `tmp_path` + `monkeypatch` で HOME / `GUILDBOTICS_CONFIG_DIR` / cwd を隔離。`test_sidecar_smoke.py` は subprocess の env でも HOME を temp に redirect し、実 `~/.guildbotics` には触れない。
- Desktop Vitest は jsdom で全 I/O を mock（実ネットワーク / 実 localStorage 非依存）。
- Playwright E2E は専用ポート（8766–8771 / 1421–1425）と専用 token、temp workspace + temp HOME を使い、開発環境の実 backend (`:8765`) や実 `~/.guildbotics` を**改変しない**。

## Test plan

- [x] Python: `uv sync --extra test --extra dev && uv run --no-sync ruff format --check guildbotics && uv run --no-sync ruff check guildbotics && uv run --no-sync mypy guildbotics && uv run --no-sync pylint guildbotics && uv run --no-sync python -m pytest tests/ --cov=guildbotics --cov-report=xml`
- [x] Desktop: `cd desktop && npm ci && npm run quality`
- [x] Desktop E2E: `cd desktop && npm run e2e:install && npm run e2e` （実 backend を起動する critical journey 群）
- [x] CI（push）で `npm run quality` および `pytest` が green であること
- [x] `docs/test_gap_analysis.ja.md` の S1〜S22 が完了マーク済み、S20/S21 が保留（理由注記あり）

🤖 Generated with [Claude Code](https://claude.com/claude-code)